### PR TITLE
chore(deploy): Ansible deploy to home server + production compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
-# Continuous Integration — runs on every push to main and every pull request.
-# Stage 2a: lint + typecheck. (Tests and image build come in later steps.)
+# Continuous Integration + Deployment.
+#   On every push to main and every PR: lint, typecheck, test, build+publish images.
+#   On push to main only (after all gates pass): auto-deploy to the home server
+#   over Tailscale (Stage 5).
 name: CI
 
 on:
@@ -118,3 +120,47 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to home server
+    # Only after images are published, and ONLY on main (never on PRs).
+    needs: [publish]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # Never run two deploys at once (a second push waits for the first to finish
+    # rather than interrupting a migration mid-flight).
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
+    steps:
+      # The runner lives in GitHub's cloud; the home server has no public IP and
+      # is only reachable via Tailscale. Join the tailnet as an EPHEMERAL node
+      # (auto-removed when the job ends) so we can SSH to it.
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+
+      # Load the deploy key (its public half is in zoli's authorized_keys).
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      # Roll the server forward to the freshly published :latest images. The
+      # server already holds .env + the ghcr login (from the Ansible deploy),
+      # so NO app secrets are needed in CI — only network + SSH access.
+      - name: Deploy (pull, migrate, up)
+        env:
+          HOST: zoli@100.86.236.18 # home-server's stable tailnet IP
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new "$HOST" '
+            set -euo pipefail
+            cd ~/condo-manager
+            docker compose pull
+            docker compose run --rm worker npx prisma migrate deploy
+            docker compose up -d
+            curl -sS -o /dev/null -w "health: HTTP %{http_code}\n" \
+              --retry 10 --retry-delay 3 --retry-all-errors http://localhost:3000
+          '

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ docker-compose.override.yml
 
 # Playwright MCP scratch output (snapshots/screenshots) — tooling artifact
 .playwright-mcp/
+
+# Ansible deploy secrets (ghcr PAT, NEXTAUTH_SECRET, DB password). Real values
+# live only on the laptop; commit secrets.example.yml as the template instead.
+ansible/secrets.yml

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,10 @@
+# Ansible config for deploying condo-manager to the home server.
+# Run ansible commands from inside this `ansible/` directory.
+[defaults]
+inventory = inventory.ini
+# Don't prompt to accept the server's SSH host key on first connect. Fine over
+# a trusted Tailscale network for a personal server; revisit if this ever
+# faces untrusted networks.
+host_key_checking = False
+# Let Ansible pick the remote Python interpreter without warnings.
+interpreter_python = auto_silent

--- a/ansible/check-docker.yml
+++ b/ansible/check-docker.yml
@@ -1,0 +1,24 @@
+# Stage 3, step 2: check Docker prerequisites AS the deploy user (zoli), no sudo.
+# Tells us whether zoli can drive Docker directly, or needs the docker group.
+#   cd ansible && ansible-playbook check-docker.yml
+- name: Check Docker prerequisites
+  hosts: homeserver
+  gather_facts: false
+  tasks:
+    - name: Can zoli reach the Docker daemon? (no sudo)
+      ansible.builtin.command: docker ps
+      register: docker_ps
+      changed_when: false
+      failed_when: false
+
+    - name: Is the compose v2 plugin available?
+      ansible.builtin.command: docker compose version --short
+      register: compose_v
+      changed_when: false
+      failed_when: false
+
+    - name: Report
+      ansible.builtin.debug:
+        msg:
+          - "docker ps  -> rc={{ docker_ps.rc }} {{ docker_ps.stderr | default('') }}"
+          - "compose    -> rc={{ compose_v.rc }} v{{ compose_v.stdout | default('') }}"

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,0 +1,72 @@
+# Stage 3, step 3: deploy condo-manager to the home server.
+#   cd ansible && ansible-playbook deploy.yml -e @secrets.yml
+#
+# No `become:` — zoli owns the deploy dir and can drive Docker without root.
+- name: Deploy condo-manager
+  hosts: homeserver
+  gather_facts: false
+  vars:
+    deploy_dir: /home/zoli/condo-manager
+  tasks:
+    - name: Ensure the deploy directory exists
+      ansible.builtin.file:
+        path: "{{ deploy_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Copy the production compose file
+      ansible.builtin.copy:
+        src: ../deploy/docker-compose.prod.yml
+        dest: "{{ deploy_dir }}/docker-compose.yml"
+        mode: "0644"
+
+    - name: Template the secret .env
+      ansible.builtin.template:
+        src: templates/env.j2
+        dest: "{{ deploy_dir }}/.env"
+        mode: "0600"
+
+    - name: Log in to ghcr.io with the read-only PAT
+      ansible.builtin.command:
+        cmd: docker login ghcr.io -u {{ ghcr_user }} --password-stdin
+        stdin: "{{ ghcr_pat }}"
+      no_log: true # never print the PAT
+      changed_when: true
+
+    - name: Pull images from ghcr
+      ansible.builtin.command:
+        cmd: docker compose pull
+        chdir: "{{ deploy_dir }}"
+      changed_when: true
+
+    - name: Run database migrations (worker image ships prisma + migrations)
+      ansible.builtin.command:
+        cmd: docker compose run --rm worker npx prisma migrate deploy
+        chdir: "{{ deploy_dir }}"
+      changed_when: true
+
+    - name: Start the stack
+      ansible.builtin.command:
+        cmd: docker compose up -d
+        chdir: "{{ deploy_dir }}"
+      changed_when: true
+
+    - name: Wait for the app to listen on localhost:3000
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 3000
+        timeout: 120
+
+    - name: Confirm the app answers HTTP
+      ansible.builtin.uri:
+        url: http://localhost:3000
+        status_code: [200, 302, 307, 308]
+        follow_redirects: none
+      register: health
+      retries: 10
+      delay: 3
+      until: health.status is defined
+
+    - name: Report
+      ansible.builtin.debug:
+        msg: "app responded with HTTP {{ health.status }} — deploy is up"

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,12 @@
+# Which machine(s) Ansible manages, and how to reach them.
+#
+# FILL IN the two placeholders below:
+#   ansible_host = your server's Tailscale name or IP (run `tailscale status`
+#                  on the server/laptop — e.g. condo-server or 100.x.y.z)
+#   ansible_user = the SSH user that exists on the server (e.g. ubuntu, zoltan)
+#
+# Prereq: `ssh <ansible_user>@<ansible_host>` must already work from this laptop
+# (key-based or Tailscale SSH). Ansible just rides that same SSH path.
+
+[homeserver]
+home-server ansible_host=home-server ansible_user=zoli

--- a/ansible/ping.yml
+++ b/ansible/ping.yml
@@ -1,0 +1,14 @@
+# Stage 3, step 1: prove Ansible can reach the server. Makes NO changes.
+#   cd ansible && ansible-playbook ping.yml
+- name: Connectivity check
+  hosts: homeserver
+  gather_facts: true
+  tasks:
+    - name: Ping (SSH + Python reachable?)
+      ansible.builtin.ping:
+
+    - name: Report what we connected to
+      ansible.builtin.debug:
+        msg: >-
+          {{ ansible_distribution }} {{ ansible_distribution_version }}
+          ({{ ansible_architecture }}) — Python {{ ansible_python_version }}

--- a/ansible/secrets.example.yml
+++ b/ansible/secrets.example.yml
@@ -1,0 +1,19 @@
+# Copy this to `secrets.yml` (gitignored), fill in real values, then deploy:
+#   cd ansible && ansible-playbook deploy.yml -e @secrets.yml
+#
+# These are the only secrets the deploy needs. They never get committed; the
+# playbook templates them into a 0600 .env on the server.
+
+# --- ghcr image pull ---
+# A GitHub Personal Access Token (classic) with ONLY the `read:packages` scope.
+# Create: https://github.com/settings/tokens -> Generate new token (classic).
+ghcr_user: siposzoltan03
+ghcr_pat: "ghp_PASTE_YOUR_READ_PACKAGES_TOKEN"
+
+# --- app secrets ---
+# NextAuth signing key. Generate with:  openssl rand -base64 32
+nextauth_secret: "REPLACE_WITH_openssl_rand_base64_32"
+
+# Postgres password. Use hex (URL-safe — it goes inside DATABASE_URL):
+#   openssl rand -hex 24
+postgres_password: "REPLACE_WITH_openssl_rand_hex_24"

--- a/ansible/templates/env.j2
+++ b/ansible/templates/env.j2
@@ -4,8 +4,7 @@ NODE_ENV=production
 DATABASE_URL=postgresql://condo:{{ postgres_password }}@db:5432/condo_manager
 REDIS_URL=redis://redis:6379
 NEXTAUTH_SECRET={{ nextauth_secret }}
-# Placeholder for the first deploy (smoke-tested via curl on the server).
-# Stage 4 (Tailscale serve) replaces this with the real https://*.ts.net URL.
-NEXTAUTH_URL=http://home-server:3000
+# Public HTTPS URL provided by `tailscale serve` (terminates TLS, proxies to :3000).
+NEXTAUTH_URL=https://home-server.tailebf7d7.ts.net
 AUTH_TRUST_HOST=true
 POSTGRES_PASSWORD={{ postgres_password }}

--- a/ansible/templates/env.j2
+++ b/ansible/templates/env.j2
@@ -1,0 +1,11 @@
+# Rendered by Ansible (ansible/templates/env.j2) onto the server as .env (0600).
+# Service names (db, redis) resolve inside the compose network.
+NODE_ENV=production
+DATABASE_URL=postgresql://condo:{{ postgres_password }}@db:5432/condo_manager
+REDIS_URL=redis://redis:6379
+NEXTAUTH_SECRET={{ nextauth_secret }}
+# Placeholder for the first deploy (smoke-tested via curl on the server).
+# Stage 4 (Tailscale serve) replaces this with the real https://*.ts.net URL.
+NEXTAUTH_URL=http://home-server:3000
+AUTH_TRUST_HOST=true
+POSTGRES_PASSWORD={{ postgres_password }}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,48 @@
+# Production compose for the home server. Ansible copies this to the server and
+# runs it. Key differences from the dev docker-compose.yml:
+#   - `image:` (pulled from ghcr, built by CI) instead of `build:` — the server
+#     never compiles; it runs the exact artifact CI published.
+#   - `restart: unless-stopped` — containers come back after crashes/reboots.
+#   - app binds to 127.0.0.1 only — NOT exposed on the network. Tailscale
+#     `serve` (Stage 4) terminates HTTPS and proxies to it.
+#   - secrets come from a server-side `.env` (templated by Ansible, never committed).
+services:
+  app:
+    image: ghcr.io/siposzoltan03/condo-manager-app:latest
+    restart: unless-stopped
+    env_file: [.env]
+    depends_on:
+      db: { condition: service_healthy }
+      redis: { condition: service_started }
+    ports:
+      - "127.0.0.1:3000:3000" # localhost-only; Tailscale fronts it
+
+  worker:
+    image: ghcr.io/siposzoltan03/condo-manager-worker:latest
+    restart: unless-stopped
+    env_file: [.env]
+    depends_on:
+      db: { condition: service_healthy }
+      redis: { condition: service_started }
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: condo
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # from .env
+      POSTGRES_DB: condo_manager
+    volumes:
+      - pgdata:/var/lib/postgresql/data # data survives container restarts
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U condo -d condo_manager"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Stage 3 of the DevOps learning track: infrastructure-as-code that deploys the ghcr-published images to the Tailscale-reachable home server.

## What's here
- **deploy/docker-compose.prod.yml** — production compose: pulls `app`/`worker` images from ghcr (no build), `restart: unless-stopped`, app bound to `127.0.0.1:3000` only (Tailscale will front it), Postgres healthcheck + `pgdata` volume.
- **ansible/** — `ping.yml` (connectivity), `check-docker.yml` (Docker prereq check, no sudo), `deploy.yml` (copy compose → template `0600` `.env` → `docker login ghcr` → `compose pull` → `prisma migrate deploy` via the worker image → `compose up -d` → HTTP health check).
- **ansible/secrets.example.yml** — template; real `secrets.yml` is gitignored.

## Verified
Deployed to `home-server` end-to-end: `ok=10 failed=0`, app responded `HTTP 307`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)