### PR TITLE
feat(monitoring): Prometheus + Grafana + exporters (Stage 6)

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -1,0 +1,53 @@
+# Stage 6: deploy the observability stack (Prometheus + Grafana + exporters).
+#   cd ansible && ansible-playbook monitoring.yml -e @secrets.yml
+- name: Deploy monitoring stack
+  hosts: homeserver
+  gather_facts: false
+  vars:
+    mon_dir: /home/zoli/monitoring
+  tasks:
+    - name: Ensure the monitoring directory exists
+      ansible.builtin.file:
+        path: "{{ mon_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Copy the monitoring stack (compose + prometheus + grafana config)
+      ansible.builtin.copy:
+        src: ../monitoring/
+        dest: "{{ mon_dir }}/"
+        mode: preserve
+
+    - name: Template the Grafana env (admin password)
+      ansible.builtin.template:
+        src: templates/monitoring.env.j2
+        dest: "{{ mon_dir }}/.env"
+        mode: "0600"
+
+    - name: Pull and start the monitoring stack
+      ansible.builtin.command:
+        cmd: docker compose up -d --pull always
+        chdir: "{{ mon_dir }}"
+      changed_when: true
+
+    - name: Wait for Prometheus
+      ansible.builtin.wait_for: { host: 127.0.0.1, port: 9090, timeout: 60 }
+
+    - name: Wait for Grafana
+      ansible.builtin.wait_for: { host: 127.0.0.1, port: 3001, timeout: 60 }
+
+    - name: Query Prometheus for scrape-target health
+      ansible.builtin.uri:
+        url: http://localhost:9090/api/v1/targets?state=active
+        return_content: true
+      register: targets
+      retries: 12
+      delay: 5
+      until: targets.status == 200 and targets.json.data.activeTargets | length > 0
+
+    - name: Report target health (may take one 15s scrape to all go 'up')
+      ansible.builtin.debug:
+        msg: >-
+          {{ targets.json.data.activeTargets | length }} targets;
+          up={{ targets.json.data.activeTargets | selectattr('health','equalto','up') | list | length }};
+          jobs={{ targets.json.data.activeTargets | map(attribute='labels.job') | list }}

--- a/ansible/secrets.example.yml
+++ b/ansible/secrets.example.yml
@@ -17,3 +17,6 @@ nextauth_secret: "REPLACE_WITH_openssl_rand_base64_32"
 # Postgres password. Use hex (URL-safe — it goes inside DATABASE_URL):
 #   openssl rand -hex 24
 postgres_password: "REPLACE_WITH_openssl_rand_hex_24"
+
+# Grafana admin password (Stage 6 monitoring). openssl rand -hex 16
+grafana_admin_password: "REPLACE_WITH_openssl_rand_hex_16"

--- a/ansible/templates/monitoring.env.j2
+++ b/ansible/templates/monitoring.env.j2
@@ -1,0 +1,4 @@
+# Rendered by Ansible onto the server as monitoring/.env (0600).
+GF_SECURITY_ADMIN_PASSWORD={{ grafana_admin_password }}
+# Grafana will be fronted by `tailscale serve` on :8443 (set up after deploy).
+GF_SERVER_ROOT_URL=https://home-server.tailebf7d7.ts.net:8443

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,58 @@
+# Observability stack for the home server — runs as its own compose project,
+# separate from the app stack (independent lifecycle). cAdvisor + node-exporter
+# expose metrics; Prometheus scrapes & stores them; Grafana visualizes.
+# Everything binds to 127.0.0.1; reach Grafana via Tailscale or an SSH tunnel.
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - promdata:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d # keep 15 days of history
+    ports:
+      - "127.0.0.1:9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    restart: unless-stopped
+    env_file: [.env] # GRAFANA_ADMIN_PASSWORD, GF_SERVER_ROOT_URL
+    environment:
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "127.0.0.1:3001:3000" # Grafana's internal port is 3000; expose on 3001
+    depends_on: [prometheus]
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    restart: unless-stopped
+    pid: host # see the host's processes, not just the container's
+    command:
+      - --path.rootfs=/host
+    volumes:
+      - /:/host:ro,rslave # read the host filesystem for disk metrics
+    # No published port — Prometheus scrapes it at node-exporter:9100 on the
+    # compose network.
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    restart: unless-stopped
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    # Scraped at cadvisor:8080 on the compose network.
+
+volumes:
+  promdata:
+  grafanadata:

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+# Auto-configures the Prometheus data source on Grafana startup, so you don't
+# have to add it by hand in the UI.
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy # Grafana's backend queries Prometheus (server-to-server)
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,18 @@
+# What Prometheus scrapes and how often. Targets use compose service names,
+# resolved on the monitoring network.
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: prometheus # Prometheus scraping itself
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: node # host vitals (CPU, RAM, disk, net)
+    static_configs:
+      - targets: ["node-exporter:9100"]
+
+  - job_name: cadvisor # per-container metrics
+    static_configs:
+      - targets: ["cadvisor:8080"]


### PR DESCRIPTION
Stage 6 of the DevOps learning track — infrastructure observability for the home server.

## What's here
- **monitoring/docker-compose.yml** — Prometheus (15d retention), Grafana (auto-provisioned Prometheus datasource), node-exporter (host CPU/RAM/disk/net), cAdvisor (per-container). All bound to `127.0.0.1`.
- **monitoring/prometheus/prometheus.yml** — scrapes node-exporter, cAdvisor, and itself every 15s.
- **ansible/monitoring.yml** — copies the stack, templates the Grafana `.env`, `up -d`, and asserts scrape targets register.
- Grafana fronted by `tailscale serve` on **:8443**; dashboards **1860** (Node Exporter Full) and **14282** (cAdvisor) imported via the Grafana API.

## Verified
Deployed to `home-server`: all 3 scrape targets `up`; live data (14 GB RAM free, 4 cores, 11 containers). Grafana reachable at `https://home-server.tailebf7d7.ts.net:8443` (HTTP 200, valid TLS).

Note: secrets (`grafana_admin_password`) live in the gitignored `ansible/secrets.yml`; only the example is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)