### PR TITLE
chore(ci): harden pipeline (@v5 actions, paths-ignore, build-env)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ name: CI
 on:
   push:
     branches: [main]
+    # These paths don't affect the built image or what the CD job does (it pulls
+    # images + runs the server's own compose). Skip the whole pipeline — and the
+    # redeploy — when a push touches ONLY these.
+    paths-ignore:
+      - "docs/**"
+      - "monitoring/**"
+      - "ansible/**"
+      - "**/*.md"
   pull_request:
 
 jobs:
@@ -15,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest # fresh throwaway VM (x86_64, like your server)
     steps:
       # 1. Pull the repo's code onto the runner.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # 2. Install Node 22 (matches the Dockerfile) + cache ~/.npm for speed.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -68,8 +76,8 @@ jobs:
       # it comes from .env; CI has no .env, so declare it here.)
       STRIPE_WEBHOOK_SECRET: whsec_test_secret
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -92,7 +100,7 @@ jobs:
           - image: condo-manager-worker
             dockerfile: Dockerfile.worker
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-buildx-action@v3 # enables buildx + layer caching
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,15 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npx prisma@6 generate
-# Provide dummy env vars during build to prevent connection attempts during prerendering
-ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
-ENV REDIS_URL="redis://localhost:6379"
-ENV NEXTAUTH_SECRET="build-time-secret"
-ENV NEXTAUTH_URL="http://localhost:3000"
-ENV SKIP_BUILD_CONNECTIONS="true"
-RUN npm run build
+# Dummy env vars, scoped to the build command only (no persistent ENV layers,
+# and nothing secret-shaped is baked into an image layer). They just keep
+# prerendering from attempting real connections. Runtime values come from .env.
+RUN DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" \
+    REDIS_URL="redis://localhost:6379" \
+    NEXTAUTH_SECRET="build-time-secret" \
+    NEXTAUTH_URL="http://localhost:3000" \
+    SKIP_BUILD_CONNECTIONS="true" \
+    npm run build
 
 FROM node:22-alpine AS runner
 WORKDIR /app


### PR DESCRIPTION
Backlog hardening batch.

- **Actions @v5**: bump `actions/checkout` and `actions/setup-node` v4→v5, clearing the Node 20 deprecation warnings.
- **paths-ignore**: pushes to `main` that touch only `docs/**`, `monitoring/**`, `ansible/**`, or `**/*.md` no longer trigger the pipeline — so editing infra/docs won't rebuild images or redeploy the app. (These paths don't affect the built image, and the CD job pulls images + uses the server's own compose.)
- **Dockerfile**: the dummy build-time env vars are now scoped to the `RUN` instead of persistent `ENV` instructions — no secret-shaped ENV layers, silencing the `SecretsUsedInArgOrEnv` warning. The `publish` job in this PR rebuilds the image, which validates the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)