### PR TITLE
feat(observability): app-level Prometheus metrics (prom-client)

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - --storage.tsdb.retention.time=15d # keep 15 days of history
     ports:
       - "127.0.0.1:9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # reach the app on the host's :3000
 
   grafana:
     image: grafana/grafana:latest

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -16,3 +16,10 @@ scrape_configs:
   - job_name: cadvisor # per-container metrics
     static_configs:
       - targets: ["cadvisor:8080"]
+
+  - job_name: condo-app # the app's own /api/metrics (prom-client)
+    metrics_path: /api/metrics
+    static_configs:
+      # The app binds to the host's 127.0.0.1:3000; reach the host from inside
+      # the monitoring network via host.docker.internal (see extra_hosts).
+      - targets: ["host.docker.internal:3000"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next-intl": "^4.1.0",
         "nodemailer": "^6.10.0",
         "otplib": "^13.4.0",
+        "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2435,7 +2436,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -8772,6 +8772,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/birpc": {
       "version": "2.9.0",
@@ -17500,6 +17506,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -19603,6 +19622,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/temp-dir": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "next-intl": "^4.1.0",
     "nodemailer": "^6.10.0",
     "otplib": "^13.4.0",
+    "prom-client": "^15.1.3",
     "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,14 @@
+// Prometheus scrape endpoint. Exposes the app's process metrics in text format.
+// Note: reachable on the tailnet via the app's public URL — acceptable for a
+// private tailnet; protect or move to a separate port if ever made public.
+import { registry } from "@/lib/metrics";
+
+export const dynamic = "force-dynamic"; // never cache; always read live values
+export const runtime = "nodejs"; // prom-client needs the Node runtime
+
+export async function GET() {
+  const body = await registry.metrics();
+  return new Response(body, {
+    headers: { "Content-Type": registry.contentType },
+  });
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,7 @@
+// Next.js calls register() once at server startup. Initialize metrics in the
+// Node runtime only — prom-client can't run on the edge runtime.
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./lib/metrics");
+  }
+}

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,23 @@
+// Prometheus metrics registry for the app. Single instance per process; the
+// globalThis guard keeps dev HMR / repeated imports from re-registering metrics
+// (prom-client throws on duplicate registration).
+import { Registry, collectDefaultMetrics, Gauge } from "prom-client";
+
+const globalForMetrics = globalThis as unknown as {
+  __condoMetricsRegistry?: Registry;
+};
+
+export const registry: Registry =
+  globalForMetrics.__condoMetricsRegistry ?? new Registry();
+
+if (!globalForMetrics.__condoMetricsRegistry) {
+  registry.setDefaultLabels({ app: "condo-manager" });
+  // Node process vitals: CPU, RSS/heap, event-loop lag, GC, handles, etc.
+  collectDefaultMetrics({ register: registry });
+  new Gauge({
+    name: "condo_app_info",
+    help: "Static app-up indicator (always 1 while the process is alive).",
+    registers: [registry],
+  }).set(1);
+  globalForMetrics.__condoMetricsRegistry = registry;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -55,6 +55,7 @@ function isPublicAccessiblePage(pathname: string): boolean {
 
 function isPublicApiRoute(pathname: string): boolean {
   return (
+    pathname === "/api/metrics" || // Prometheus scrape endpoint (tailnet-only)
     pathname.startsWith("/api/auth") ||
     pathname.startsWith("/api/contractor/auth/signup") ||
     pathname.startsWith("/api/contractor/auth/check-tax-id") ||


### PR DESCRIPTION
Adds application-level metrics to complement the host (node-exporter) and container (cAdvisor) metrics from Stage 6.

## What's here
- **prom-client** + `src/lib/metrics.ts` — one registry per process (globalThis-guarded), default Node process metrics (CPU, heap/RSS, event-loop lag, GC) + a `condo_app_info` gauge.
- **src/instrumentation.ts** — initializes metrics at server startup (node runtime only; prom-client can't run on edge).
- **GET /api/metrics** — the scrape endpoint (`force-dynamic`, node runtime).
- **middleware** — allowlist `/api/metrics` (it was returning 401 behind the auth guard — caught by actually hitting the endpoint, not by typecheck).
- **prometheus.yml** — new `condo-app` scrape job at `host.docker.internal:3000/api/metrics`; `extra_hosts: host-gateway` lets Prometheus reach the app on the host.

## Verified locally
`/api/metrics` → 200 in the running app, returning `process_resident_memory_bytes`, `nodejs_heap_size_used_bytes`, `condo_app_info{app="condo-manager"} 1`. tsc + lint clean.

Note: the endpoint is reachable on the tailnet via the app URL — fine for a private tailnet; would protect/relocate it before any public exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)