### PR TITLE
fix(monitoring): scrape app via shared network

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -14,8 +14,9 @@ services:
       - --storage.tsdb.retention.time=15d # keep 15 days of history
     ports:
       - "127.0.0.1:9090:9090"
-    extra_hosts:
-      - "host.docker.internal:host-gateway" # reach the app on the host's :3000
+    networks:
+      - default # monitoring network (node-exporter, cadvisor, grafana)
+      - appnet # the app's network, to scrape the app container directly
 
   grafana:
     image: grafana/grafana:latest
@@ -58,3 +59,9 @@ services:
 volumes:
   promdata:
   grafanadata:
+
+networks:
+  default: {} # this monitoring project's own network
+  appnet: # the app stack's network, joined so Prometheus can reach the app
+    external: true
+    name: condo-manager_default

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -20,6 +20,7 @@ scrape_configs:
   - job_name: condo-app # the app's own /api/metrics (prom-client)
     metrics_path: /api/metrics
     static_configs:
-      # The app binds to the host's 127.0.0.1:3000; reach the host from inside
-      # the monitoring network via host.docker.internal (see extra_hosts).
-      - targets: ["host.docker.internal:3000"]
+      # Prometheus joins the app's network (appnet), so it reaches the app
+      # container directly by service name — the app listens on 0.0.0.0:3000
+      # inside its container (the 127.0.0.1 bind only restricts the host port).
+      - targets: ["app:3000"]


### PR DESCRIPTION
Follow-up to #55. The app binds to `127.0.0.1:3000` on the host, so Prometheus (a container) couldn't reach it via `host.docker.internal`/host-gateway (`connection refused` to 172.17.0.1:3000).

Fix: join Prometheus to the app's external network (`condo-manager_default`) and scrape the app container directly at `app:3000` — it listens on `0.0.0.0:3000` *inside* its container, so the localhost host-port bind doesn't block container-to-container traffic.

Verified on the server: `condo-app` target `up`, metrics labeled `{job=condo-app, instance=app:3000}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)