### PR TITLE
feat(monitoring): centralized logs with Loki + Grafana Alloy

### DIFF
--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -1,0 +1,33 @@
+// Grafana Alloy: collect Docker container logs and push them to Loki.
+// River-style config. Pipeline: discover containers -> relabel -> tail -> write.
+
+// 1. Discover all containers from the Docker daemon.
+discovery.docker "all" {
+	host = "unix:///var/run/docker.sock"
+}
+
+// 2. Turn the docker name ("/condo-manager-app-1") into a clean `container` label.
+discovery.relabel "logs" {
+	targets = discovery.docker.all.targets
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
+}
+
+// 3. Tail each container's stdout/stderr and forward to the Loki writer.
+loki.source.docker "default" {
+	host       = "unix:///var/run/docker.sock"
+	targets    = discovery.relabel.logs.output
+	labels     = { job = "docker" }
+	forward_to = [loki.write.default.receiver]
+}
+
+// 4. Ship to Loki (same monitoring network).
+loki.write "default" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -57,9 +57,42 @@ services:
       - /dev/disk/:/dev/disk:ro
     # Scraped at cadvisor:8080 on the compose network.
 
+  # Loki: stores & queries logs (what Prometheus is for metrics). The image
+  # ships a working single-node config; we just persist its data.
+  loki:
+    image: grafana/loki:latest
+    restart: unless-stopped
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - lokidata:/loki
+    ports:
+      - "127.0.0.1:3100:3100" # localhost only (for verification/queries)
+
+  # Alloy: tails every container's stdout/stderr via the Docker socket and
+  # pushes the lines to Loki. No app changes needed — it ships what containers
+  # already print.
+  alloy:
+    image: grafana/alloy:latest
+    restart: unless-stopped
+    user: root # needs to read the Docker socket (root:docker)
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      - --server.http.listen-addr=0.0.0.0:12345
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - alloydata:/var/lib/alloy/data
+    ports:
+      - "127.0.0.1:12345:12345" # Alloy's own UI (localhost only)
+    depends_on: [loki]
+
 volumes:
   promdata:
   grafanadata:
+  lokidata:
+  alloydata:
 
 networks:
   default: {} # this monitoring project's own network

--- a/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,7 @@
+# Auto-configures Loki as a Grafana data source (logs), alongside Prometheus.
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy # Grafana's backend queries Loki server-to-server
+    url: http://loki:3100


### PR DESCRIPTION
Stage 8 — logs in Grafana.

- **Loki** stores/queries logs (the logs counterpart to Prometheus).
- **Grafana Alloy** discovers all containers via the Docker socket, tails their stdout/stderr, and pushes to Loki (`monitoring/alloy/config.alloy`).
- **Loki datasource** provisioned in Grafana.

No app changes — Alloy ships what containers already print. Verified on the server: logs flowing from all containers (app/worker/db/monitoring), Loki datasource live in Grafana. Query in Explore: `{container="condo-manager-app-1"}`, `{job="docker"} |= "error"`.

Next (optional): structured JSON logging (`pino`) in the app for queryable fields (`level`, `route`, `userId`), then `{job="condo-app"} | json | level="error"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)