### PR TITLE
fix(deploy): persistent + shared + writable uploads volume

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -12,18 +12,28 @@ services:
     restart: unless-stopped
     env_file: [.env]
     depends_on:
+      uploads-init: { condition: service_completed_successfully }
       db: { condition: service_healthy }
       redis: { condition: service_started }
     ports:
       - "127.0.0.1:3000:3000" # localhost-only; Tailscale fronts it
+    volumes:
+      # Persist uploads across redeploys AND share them with the worker:
+      # getStorage() writes to <cwd>/uploads = /app/uploads.
+      - uploads:/app/uploads
 
   worker:
     image: ghcr.io/siposzoltan03/condo-manager-worker:latest
     restart: unless-stopped
     env_file: [.env]
     depends_on:
+      uploads-init: { condition: service_completed_successfully }
       db: { condition: service_healthy }
       redis: { condition: service_started }
+    volumes:
+      # SAME named volume as app — the worker generates report files that the
+      # app then serves, so they must share one storage location.
+      - uploads:/app/uploads
 
   db:
     image: postgres:16-alpine
@@ -44,5 +54,17 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
 
+  # One-shot init: a fresh named volume is owned by root, but the app/worker run
+  # as uid 1001 (nextjs). chown the uploads volume so they can write to it.
+  # Runs to completion before app/worker start (idempotent on every deploy).
+  uploads-init:
+    image: busybox:latest
+    user: "0:0" # root, to chown
+    command: ["sh", "-c", "mkdir -p /app/uploads && chown -R 1001:1001 /app/uploads"]
+    volumes:
+      - uploads:/app/uploads
+    restart: "no"
+
 volumes:
   pgdata:
+  uploads: # shared file storage for app + worker (survives redeploys)


### PR DESCRIPTION
Fixes a live data-loss + correctness bug in the prod deployment.

`getStorage()` writes to `/app/uploads`, but the prod compose mounted **no volume** there:
1. **Data loss** — uploads were wiped on every CD redeploy.
2. **Correctness** — the worker writes generated reports via `getStorage().put()`; the app serves them. With no shared storage, the worker wrote to its own ephemeral dir, invisible to the app.

## Fix
- One named `uploads` volume, mounted on **both** app and worker (so they share storage and it survives redeploys).
- A one-shot `uploads-init` (busybox as root) that `chown`s the volume to **uid 1001** before app/worker start — a fresh named volume is root-owned, but the containers run as `nextjs` (1001) and couldn't otherwise write.

## Verified on the server
`uploads-init` exits 0; the app writes as `nextjs`; the file **survives a force-recreate**; the **worker reads the same file**.

Applied via `ansible-playbook deploy.yml` (CD uses the server's own compose copy, so compose changes ship through Ansible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)