### PR TITLE
feat(email): wire real SMTP (Resend) into the prod deploy

### DIFF
--- a/ansible/secrets.example.yml
+++ b/ansible/secrets.example.yml
@@ -20,3 +20,13 @@ postgres_password: "REPLACE_WITH_openssl_rand_hex_24"
 
 # Grafana admin password (Stage 6 monitoring). openssl rand -hex 16
 grafana_admin_password: "REPLACE_WITH_openssl_rand_hex_16"
+
+# --- email / SMTP ---
+# From a transactional email provider (e.g. Resend: host smtp.resend.com,
+# port 465, user "resend", pass = the API key). SMTP_FROM must be on a domain
+# you've verified with the provider (SPF/DKIM), or the provider's test domain.
+smtp_host: "smtp.resend.com"
+smtp_port: "465"
+smtp_user: "resend"
+smtp_pass: "REPLACE_WITH_PROVIDER_API_KEY_OR_SMTP_PASSWORD"
+smtp_from: "Condo Manager <noreply@yourdomain.example>"

--- a/ansible/templates/env.j2
+++ b/ansible/templates/env.j2
@@ -8,3 +8,14 @@ NEXTAUTH_SECRET={{ nextauth_secret }}
 NEXTAUTH_URL=https://home-server.tailebf7d7.ts.net
 AUTH_TRUST_HOST=true
 POSTGRES_PASSWORD={{ postgres_password }}
+
+# Email (SMTP). Works with any transactional provider's SMTP endpoint
+# (Resend, SendGrid, Mailgun, SES, ...). Rendered only once smtp_* is set in
+# secrets.yml — until then the app keeps its no-op localhost defaults.
+{% if smtp_host is defined %}
+SMTP_HOST={{ smtp_host }}
+SMTP_PORT={{ smtp_port }}
+SMTP_USER={{ smtp_user }}
+SMTP_PASS={{ smtp_pass }}
+SMTP_FROM={{ smtp_from }}
+{% endif %}


### PR DESCRIPTION
The app sends email via nodemailer/SMTP (`src/lib/email.ts`, env `SMTP_HOST/PORT/USER/PASS/FROM`), but the prod `.env` set none of it — so invitations, password resets, verification, and notifications silently went nowhere.

- Template the `SMTP_*` vars into the server `.env` from `secrets.yml` (conditional block — only rendered once `smtp_*` is set, so it no-ops cleanly until configured).
- `secrets.example.yml` documents Resend's SMTP settings.
- Dev still uses MailHog/Mailpit; no code change needed (the mailer is provider-agnostic).

**Verified:** real send through Resend returned `250 OK`.

Note: started on Resend's **test domain** (`onboarding@resend.dev`), which only delivers to the account's own address. Sending to real users requires verifying a domain (SPF/DKIM) and changing `smtp_from`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)