### PR TITLE
feat(email): send via the worker queue instead of inline

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,28 +1,21 @@
-import nodemailer from "nodemailer";
+import { notificationsQueue } from "./queue";
 
-const smtpPort = parseInt(process.env.SMTP_PORT ?? "1025", 10);
-
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST ?? "localhost",
-  port: smtpPort,
-  secure: smtpPort === 465,
-  auth:
-    process.env.SMTP_USER && process.env.SMTP_PASS
-      ? {
-          user: process.env.SMTP_USER,
-          pass: process.env.SMTP_PASS,
-        }
-      : undefined,
-});
-
+/**
+ * Queue an email for asynchronous delivery by the worker.
+ *
+ * This returns as soon as the job is enqueued — the actual SMTP send happens
+ * in the worker (worker/processors/email.ts) under the notifications queue's
+ * retry policy (3 attempts, exponential backoff). That keeps a slow or failing
+ * mail server from blocking (or failing) the request that triggered the email.
+ *
+ * The signature is unchanged from the old inline sender, so every caller keeps
+ * working without modification.
+ */
 export async function sendEmail(
   to: string,
   subject: string,
-  html: string
+  html: string,
 ): Promise<void> {
-  const from = process.env.SMTP_FROM ?? "noreply@condo-manager.local";
-
-  await transporter.sendMail({ from, to, subject, html });
-
-  console.log(`[email] Sent to ${to}: ${subject}`);
+  await notificationsQueue.add("send-email", { to, subject, html });
+  console.log(`[email] queued -> ${to}: ${subject}`);
 }


### PR DESCRIPTION
Moves email off the request path and onto the existing BullMQ worker.

`sendEmail()` now enqueues a `send-email` job on the **notifications** queue instead of calling SMTP synchronously. The worker already handles that job (`worker/jobs.ts` → `worker/processors/email.ts`), so:
- Delivery runs in the background with the queue's **retry/backoff** (3 attempts, exponential) — transient SMTP failures auto-retry.
- A slow/failing mail server no longer blocks or fails the user's request (registration, invitations, etc.).
- **Signature unchanged**, so all ~8 callers keep working as-is.

Dev still uses MailHog; the worker's SMTP transport is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)