### PR TITLE
test(authz): big role/building/admin integration suite (Part A)

### DIFF
--- a/tests/integration/admin-feature-api.test.ts
+++ b/tests/integration/admin-feature-api.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { BuildingRole } from "@prisma/client";
+
+/**
+ * The /api/admin/* feature-console routes must be SUPER_ADMIN-only. They all
+ * share requireSuperAdmin() = requireBuildingContext() + hasMinimumRole(role,
+ * "SUPER_ADMIN"), so ADMIN (hierarchy level 4) is correctly below SUPER_ADMIN
+ * (5) and rejected. Locks that every admin endpoint denies non-superadmins.
+ */
+
+const { requireBuildingContextMock } = vi.hoisted(() => ({
+  requireBuildingContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireBuildingContext: requireBuildingContextMock,
+  getCurrentUser: vi.fn(),
+  auth: vi.fn(),
+  getSession: vi.fn(),
+  handlers: { GET: vi.fn(), POST: vi.fn() },
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const { GET: featuresGET } = await import("@/app/api/admin/features/route");
+const { GET: plansGET } = await import("@/app/api/admin/plans/route");
+const { PATCH: featuresPATCH } = await import(
+  "@/app/api/admin/features/[id]/route"
+);
+
+beforeEach(() => requireBuildingContextMock.mockReset());
+
+function asRole(role: BuildingRole) {
+  requireBuildingContextMock.mockResolvedValue({
+    userId: "u1",
+    buildingId: "b1",
+    role,
+  });
+}
+
+// Every building role that is NOT the platform superadmin.
+const NON_SUPERADMIN: BuildingRole[] = [
+  "TENANT",
+  "OWNER",
+  "BOARD_MEMBER",
+  "ADMIN",
+];
+
+describe("admin API — SUPER_ADMIN guard", () => {
+  describe("GET /api/admin/features", () => {
+    for (const role of NON_SUPERADMIN) {
+      it(`rejects ${role} with 403`, async () => {
+        asRole(role);
+        expect((await featuresGET()).status).toBe(403);
+      });
+    }
+    it("allows SUPER_ADMIN", async () => {
+      asRole("SUPER_ADMIN");
+      expect((await featuresGET()).status).toBe(200);
+    });
+  });
+
+  describe("GET /api/admin/plans", () => {
+    for (const role of NON_SUPERADMIN) {
+      it(`rejects ${role} with 403`, async () => {
+        asRole(role);
+        expect((await plansGET()).status).toBe(403);
+      });
+    }
+    it("allows SUPER_ADMIN", async () => {
+      asRole("SUPER_ADMIN");
+      expect((await plansGET()).status).toBe(200);
+    });
+  });
+
+  describe("PATCH /api/admin/features/[id] — mutations are locked too", () => {
+    it("rejects ADMIN with 403 before touching the body", async () => {
+      asRole("ADMIN");
+      const res = await featuresPATCH(
+        new NextRequest("http://test/api/admin/features/x", {
+          method: "PATCH",
+          body: "{}",
+        }),
+        { params: Promise.resolve({ id: "x" }) },
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/tests/integration/feature-resolver.test.ts
+++ b/tests/integration/feature-resolver.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { resolveFeature } from "@/lib/feature-resolver";
+import { applyDependencies } from "@/lib/feature-resolver";
+import type { Feature } from "@/lib/features";
+
+/**
+ * Pure unit coverage for the feature-gating core (src/lib/feature-resolver.ts).
+ * No existing test exercises the precedence rules or the dependency cascade
+ * directly — this locks both. Grouped into two it() blocks (precedence, cascade)
+ * to avoid per-case harness TRUNCATEs; failures show a labelled diff.
+ */
+
+describe("resolveFeature — precedence", () => {
+  it("applies kill-switch > override > force-on > plan", () => {
+    const cases: {
+      label: string;
+      input: Parameters<typeof resolveFeature>[0];
+      expected: boolean;
+    }[] = [
+      {
+        label: "kill-switch beats override + plan",
+        input: { planEnabled: true, flagState: "KILL_SWITCH", override: true },
+        expected: false,
+      },
+      {
+        label: "override grant beats plan-off",
+        input: { planEnabled: false, flagState: "PER_PLAN", override: true },
+        expected: true,
+      },
+      {
+        label: "override revoke beats force-on",
+        input: { planEnabled: true, flagState: "FORCE_ON", override: false },
+        expected: false,
+      },
+      {
+        label: "force-on beats plan-off (no override)",
+        input: { planEnabled: false, flagState: "FORCE_ON", override: null },
+        expected: true,
+      },
+      {
+        label: "plan default on (PER_PLAN, no override)",
+        input: { planEnabled: true, flagState: "PER_PLAN", override: null },
+        expected: true,
+      },
+      {
+        label: "plan default off (PER_PLAN, no override)",
+        input: { planEnabled: false, flagState: "PER_PLAN", override: null },
+        expected: false,
+      },
+    ];
+
+    const got = cases.map((c) => ({ label: c.label, r: resolveFeature(c.input) }));
+    const want = cases.map((c) => ({ label: c.label, r: c.expected }));
+    expect(got).toEqual(want);
+  });
+});
+
+describe("applyDependencies — cascade to fixpoint", () => {
+  it("drops features whose prerequisites aren't all present", () => {
+    const cases: { label: string; input: Feature[]; expected: Feature[] }[] = [
+      {
+        label: "dependent without prereq is dropped",
+        input: ["voting.weighted"],
+        expected: [],
+      },
+      {
+        label: "dependent with prereq is kept",
+        input: ["voting.basic", "voting.weighted"],
+        expected: ["voting.basic", "voting.weighted"],
+      },
+      {
+        label: "transitive chain collapses when ledger is absent",
+        input: ["finance.bank-csv", "finance.bank-sync-live"],
+        expected: [],
+      },
+      {
+        label: "full finance chain is kept",
+        input: ["finance.ledger", "finance.bank-csv", "finance.bank-sync-live"],
+        expected: ["finance.ledger", "finance.bank-csv", "finance.bank-sync-live"],
+      },
+      {
+        label: "removing ledger cascades to every dependent",
+        input: [
+          "finance.budget",
+          "finance.bank-csv",
+          "finance.bank-sync-live",
+          "finance.pdf-report",
+        ],
+        expected: [],
+      },
+      {
+        label: "a feature with no dependencies stays",
+        input: ["communication.forum"],
+        expected: ["communication.forum"],
+      },
+    ];
+
+    const got = cases.map((c) => ({
+      label: c.label,
+      set: [...applyDependencies(new Set(c.input))].sort(),
+    }));
+    const want = cases.map((c) => ({ label: c.label, set: [...c.expected].sort() }));
+    expect(got).toEqual(want);
+  });
+});

--- a/tests/integration/isolation-condo.test.ts
+++ b/tests/integration/isolation-condo.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Cross-building isolation for the building-switcher — the control that decides
+ * which building a user is allowed to make active. Entity-level isolation
+ * (finance, charges, ledger) is covered by the finance-* tests via the
+ * paired-tenant pattern; this fills the gap for the switch gate itself, which
+ * enforces membership in the DB (UserBuilding + isActive), not via the session.
+ */
+
+const { getCurrentUserMock } = vi.hoisted(() => ({
+  getCurrentUserMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser: getCurrentUserMock,
+  requireBuildingContext: vi.fn(),
+  auth: vi.fn(),
+  getSession: vi.fn(),
+  handlers: { GET: vi.fn(), POST: vi.fn() },
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// Cookie-setting needs a request scope we don't have when calling the handler
+// directly — stub it out; we're asserting the authorization decision.
+vi.mock("@/lib/building-context", () => ({
+  setActiveBuildingCookie: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { POST: switchPOST } = await import("@/app/api/buildings/switch/route");
+
+function switchReq(body: unknown) {
+  return new Request("http://test/api/buildings/switch", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  getCurrentUserMock.mockReset();
+});
+
+describe("POST /api/buildings/switch — cross-building access", () => {
+  it("allows switching to a building the user belongs to", async () => {
+    const { building } = await makeBuilding();
+    const user = await makeUser({ buildingId: building.id, role: "OWNER" });
+    getCurrentUserMock.mockResolvedValue({ id: user.id });
+
+    const res = await switchPOST(switchReq({ buildingId: building.id }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.buildingId).toBe(building.id);
+    expect(body.role).toBe("OWNER");
+  });
+
+  it("rejects switching to a building the user does NOT belong to (403)", async () => {
+    const { building, otherBuilding } = await makeBuilding();
+    const user = await makeUser({ buildingId: building.id, role: "OWNER" });
+    getCurrentUserMock.mockResolvedValue({ id: user.id });
+
+    const res = await switchPOST(switchReq({ buildingId: otherBuilding.id }));
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects switching to a building where membership is inactive (403)", async () => {
+    const { building, otherBuilding } = await makeBuilding();
+    const user = await makeUser({ buildingId: building.id, role: "OWNER" });
+    // Inactive membership in the other building — must still be rejected.
+    await prisma.userBuilding.create({
+      data: {
+        userId: user.id,
+        buildingId: otherBuilding.id,
+        role: "OWNER",
+        isActive: false,
+      },
+    });
+    getCurrentUserMock.mockResolvedValue({ id: user.id });
+
+    const res = await switchPOST(switchReq({ buildingId: otherBuilding.id }));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when buildingId is missing", async () => {
+    const { building } = await makeBuilding();
+    const user = await makeUser({ buildingId: building.id, role: "OWNER" });
+    getCurrentUserMock.mockResolvedValue({ id: user.id });
+
+    const res = await switchPOST(switchReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    getCurrentUserMock.mockResolvedValue(null);
+    const res = await switchPOST(switchReq({ buildingId: "anything" }));
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/integration/rbac-matrix.test.ts
+++ b/tests/integration/rbac-matrix.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { can, type ActorContext, type Capability } from "@/lib/capabilities";
+
+/**
+ * Locks the full capability matrix from src/lib/capabilities.ts. Data-driven:
+ * each actor variant lists the capabilities it SHOULD be allowed; every other
+ * capability must be denied. Any future change to can() that shifts a cell
+ * breaks this test on purpose.
+ */
+
+const ALL_CAPS: Capability[] = [
+  "manage.budget",
+  "approve.invoice",
+  "view.building.finance",
+  "view.own.unit.finance",
+  "vote.cast",
+  "vote.start",
+  "vote.editMinutes",
+  "ticket.report",
+  "ticket.assign",
+  "announcement.publish",
+  "announcement.boardChannel",
+  "document.publish.public",
+  "document.publish.boardOnly",
+  "residents.viewAll",
+  "residents.viewSameStaircase",
+  "platform.impersonate",
+  "platform.featureFlags",
+  "auditor.readAll",
+];
+
+// Representative-authority caps (Tht. § 43): ADMIN or BOARD_MEMBER+chair only.
+const REPRESENTATIVE: Capability[] = [
+  "manage.budget",
+  "approve.invoice",
+  "vote.start",
+  "vote.editMinutes",
+  "ticket.assign",
+  "announcement.publish",
+  "announcement.boardChannel",
+  "document.publish.public",
+  "document.publish.boardOnly",
+];
+
+interface Case {
+  name: string;
+  actor: ActorContext;
+  /** Capabilities expected ALLOWED; everything else must be denied. */
+  allowed: Capability[];
+}
+
+const cases: Case[] = [
+  {
+    name: "SUPER_ADMIN — platform caps only, never building powers",
+    actor: { role: "SUPER_ADMIN" },
+    allowed: ["platform.impersonate", "platform.featureFlags"],
+  },
+  {
+    name: "ADMIN — representative powers + building finance + residents",
+    actor: { role: "ADMIN" },
+    allowed: [
+      ...REPRESENTATIVE,
+      "view.building.finance",
+      "ticket.report",
+      "residents.viewAll",
+    ],
+  },
+  {
+    name: "BOARD_MEMBER chair — representative authority (Tht. § 43)",
+    actor: { role: "BOARD_MEMBER", isChair: true },
+    allowed: [
+      ...REPRESENTATIVE,
+      "view.building.finance",
+      "ticket.report",
+      "residents.viewAll",
+    ],
+  },
+  {
+    name: "BOARD_MEMBER non-chair — reads finance + residents, NO representative powers",
+    actor: { role: "BOARD_MEMBER", isChair: false },
+    allowed: ["view.building.finance", "ticket.report", "residents.viewAll"],
+  },
+  {
+    name: "OWNER (owns a unit) — votes, own-unit finance, same staircase",
+    actor: { role: "OWNER", ownsAnyUnit: true },
+    allowed: [
+      "view.own.unit.finance",
+      "vote.cast",
+      "ticket.report",
+      "residents.viewSameStaircase",
+    ],
+  },
+  {
+    name: "OWNER (owns no unit) — cannot vote or see own-unit finance",
+    actor: { role: "OWNER", ownsAnyUnit: false },
+    allowed: ["ticket.report", "residents.viewSameStaircase"],
+  },
+  {
+    name: "TENANT — no vote (Tht. § 38); report + same-staircase only",
+    actor: { role: "TENANT", ownsAnyUnit: false },
+    allowed: ["ticket.report", "residents.viewSameStaircase"],
+  },
+  {
+    name: "OWNER + auditor — adds building-finance view + auditor.readAll",
+    actor: { role: "OWNER", ownsAnyUnit: true, isAuditor: true },
+    allowed: [
+      "view.own.unit.finance",
+      "vote.cast",
+      "ticket.report",
+      "residents.viewSameStaircase",
+      "view.building.finance",
+      "auditor.readAll",
+    ],
+  },
+];
+
+describe("capability matrix — can()", () => {
+  // One assertion per actor (not per cap): comparing the full allowed-set
+  // gives a precise diff on failure while avoiding 144 harness TRUNCATEs.
+  for (const c of cases) {
+    it(c.name, () => {
+      const actualAllowed = ALL_CAPS.filter((cap) => can(c.actor, cap)).sort();
+      expect(actualAllowed).toEqual([...c.allowed].sort());
+    });
+  }
+});

--- a/tests/integration/role-gates-finance.test.ts
+++ b/tests/integration/role-gates-finance.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { BuildingRole } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Role-denial coverage for the board-only finance reads. Existing finance tests
+ * cover the happy path + cross-tenant isolation but never assert that OWNER /
+ * TENANT are rejected. These routes gate on hasMinimumRole(role, "BOARD_MEMBER")
+ * — the legacy flat hierarchy (src/lib/rbac.ts).
+ *
+ * Note: SUPER_ADMIN PASSES this gate (hierarchy level 5 >= 3) even though the
+ * can() capability matrix grants SUPER_ADMIN no building-level powers. That's a
+ * known legacy↔can() migration gap; we assert the ACTUAL behavior here.
+ */
+
+const { requireBuildingContextMock } = vi.hoisted(() => ({
+  requireBuildingContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireBuildingContext: requireBuildingContextMock,
+  auth: vi.fn(),
+  getSession: vi.fn(),
+  getCurrentUser: vi.fn(),
+  handlers: { GET: vi.fn(), POST: vi.fn() },
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// Isolate the ROLE gate from the FEATURE gate — always let the feature through.
+vi.mock("@/lib/feature-gate", () => ({
+  requireFeature: vi.fn().mockResolvedValue(undefined),
+  FeatureGateError: class FeatureGateError extends Error {},
+}));
+
+const { GET: accountsGET } = await import("@/app/api/finance/accounts/route");
+const { GET: ledgerExportGET } = await import(
+  "@/app/api/finance/ledger/export/route"
+);
+
+beforeEach(() => {
+  requireBuildingContextMock.mockReset();
+});
+
+// expected status per role for a board-only finance read
+const LADDER: { role: BuildingRole; expected: number }[] = [
+  { role: "TENANT", expected: 403 },
+  { role: "OWNER", expected: 403 },
+  { role: "BOARD_MEMBER", expected: 200 },
+  { role: "ADMIN", expected: 200 },
+  { role: "SUPER_ADMIN", expected: 200 }, // legacy hierarchy lets superadmin through
+];
+
+async function asRole(role: BuildingRole) {
+  const { building } = await makeBuilding();
+  const user = await makeUser({ buildingId: building.id, role });
+  await prisma.account.create({
+    data: { buildingId: building.id, name: "Cash", type: "ASSET" },
+  });
+  requireBuildingContextMock.mockResolvedValue({
+    userId: user.id,
+    buildingId: building.id,
+    role,
+  });
+  return building;
+}
+
+describe("GET /api/finance/accounts — role ladder", () => {
+  for (const { role, expected } of LADDER) {
+    it(`${role} -> ${expected}`, async () => {
+      await asRole(role);
+      const res = await accountsGET();
+      expect(res.status).toBe(expected);
+    });
+  }
+});
+
+describe("GET /api/finance/ledger/export — role ladder", () => {
+  for (const { role, expected } of LADDER) {
+    it(`${role} -> ${expected}`, async () => {
+      await asRole(role);
+      const res = await ledgerExportGET(
+        new NextRequest("http://test/api/finance/ledger/export"),
+      );
+      expect(res.status).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
Part A of the "big testing across roles, buildings, admin/superadmin" effort — exhaustive **Vitest integration** coverage of the authorization surface. **+36 tests (208 → 244).** Runs in CI (the existing `test` job).

## What's covered
- **rbac-matrix.test.ts** — data-driven lock of `can()` across 8 actor variants × all 18 capabilities (SUPER_ADMIN platform-only; chair vs non-chair; owner `ownsAnyUnit`; tenant no-vote; auditor).
- **role-gates-finance.test.ts** — role-*denial* ladder on board-only finance reads (OWNER/TENANT → 403). Documents that the legacy `hasMinimumRole` gate lets SUPER_ADMIN through the flat hierarchy — a known legacy↔`can()` gap, asserted as actual behavior.
- **isolation-condo.test.ts** — building-switch membership enforcement: non-member / inactive membership → 403, missing id → 400, unauth → 401.
- **admin-feature-api.test.ts** — `/api/admin/*` is SUPER_ADMIN-only: every non-superadmin role (incl. ADMIN) → 403 on features/plans GET and the feature PATCH; SUPER_ADMIN → 200.
- **feature-resolver.test.ts** — precedence (kill-switch > override > force-on > plan) and dependency cascade-to-fixpoint.

## Notable findings (asserted, not "fixed")
- Two guard styles coexist: legacy `hasMinimumRole` (SUPER_ADMIN passes) vs the `can()` matrix (SUPER_ADMIN denied). Tests capture each route's actual behavior.

Part B (Playwright per-role E2E + feature-console UI, local-only) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)