### PR TITLE
test(e2e): per-role auth fixtures + feature-console access boundary (Part B)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,60 @@
+# End-to-end tests (Playwright)
+
+Browser tests that drive the real app per role. **Local / on-demand** — not in
+CI (the exhaustive authorization coverage lives in the CI-gated Vitest suite,
+`tests/integration/`). E2E here is a high-fidelity smoke layer on top of that.
+
+## Run it
+
+E2E runs against a real server + the **seeded dev DB**. Seed first, then run:
+
+```bash
+# 1. infra + seed (once / when the DB is empty)
+docker compose up -d db redis
+npm run seed && npm run seed:demo && npm run seed:contractors
+
+# 2. browsers (once)
+npx playwright install chromium
+
+# 3. run
+npm run test:e2e                       # full suite
+npm run test:e2e -- --project=roles    # just the per-role authorization specs
+npm run test:e2e -- --project=chromium # the original auth/voting/maintenance specs
+```
+
+Playwright boots its own dev server on **:3000** (`webServer` in
+`playwright.config.ts`). If `:3000` is busy on your machine, free it or start a
+server yourself and set `reuseExistingServer`. The HTML report opens on failure
+(`npx playwright show-report`).
+
+> Note: `test:e2e` invokes `node node_modules/@playwright/test/cli.js test`
+> directly — the `.bin/playwright` symlink resolves to `playwright-chromium`
+> (no `test` command), so a bare `playwright test` fails.
+
+## ⚠️ Read-only against the dev DB
+
+E2E shares the dev database, so specs must stay **read-only / self-reverting** —
+navigation, assertions, and non-persisting interactions only. Destructive
+authorization checks (mutations, dependency blocks, overrides) belong in the
+Vitest integration suite, which runs against an isolated, truncated test DB.
+
+## Per-role auth fixtures
+
+`auth.setup.ts` (the `setup` project) logs in once per seeded role and saves a
+`storageState` to `e2e/.auth/{role}.json` (gitignored). Specs pick a fixture
+via `test.use({ storageState: authFile(role) })`. Roles (`e2e/auth.ts`):
+`superadmin`, `admin`, `board` (chair), `owner`, `tenant` — all `@condo.local`,
+password `password123`. `admin`'s session is also written to
+`baseline-admin.json` for the responsive-baseline specs.
+
+The `roles` project (`e2e/roles/*.spec.ts`) depends on `setup` and runs desktop
+Chrome only.
+
+## Not covered here (deferred)
+
+- **Cross-building negative cases** — covered at the integration level by
+  `tests/integration/isolation-condo.test.ts` (building-switch membership).
+- **Contractor role** — separate auth tree (`/contractor/login`); add when the
+  contractor E2E flows are built out.
+- A building-2 owner (`b2resident1@condo.local`) showed an intermittent
+  dashboard issue during fixture setup worth a separate look.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,26 +1,29 @@
-import { test as setup, expect } from "@playwright/test";
+import { test as setup } from "@playwright/test";
 import { existsSync, mkdirSync } from "fs";
-import { dirname } from "path";
-
-const AUTH_FILE = "e2e/.auth/baseline-admin.json";
+import { CONDO_USERS, loginCondo, authFile } from "./auth";
 
 /**
- * Logs in once as admin@condo.local and saves the session storageState
- * so the responsive-baseline tests can skip per-test login. Without this,
- * 30 sequential logins hit the `/api/auth/check-2fa` rate limiter.
+ * Logs in once per seeded role and saves each session's storageState to
+ * e2e/.auth/{role}.json, so the role specs skip per-test login (per-test login
+ * trips the /api/auth/check-2fa rate limiter). admin's session is also written
+ * to baseline-admin.json, which the responsive-baseline specs depend on.
  *
- * Wired as a `setup` project in playwright.config.ts; the responsive
- * viewport projects depend on it.
+ * All logins run sequentially inside a single setup test (fresh context each)
+ * to stay well under the login rate limiter. Wired as the `setup` project in
+ * playwright.config.ts.
  */
-setup("authenticate as admin", async ({ page }) => {
-  if (!existsSync(dirname(AUTH_FILE))) {
-    mkdirSync(dirname(AUTH_FILE), { recursive: true });
+setup("authenticate all roles", async ({ browser }) => {
+  if (!existsSync("e2e/.auth")) mkdirSync("e2e/.auth", { recursive: true });
+
+  for (const [role, email] of Object.entries(CONDO_USERS)) {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await loginCondo(page, email);
+    await context.storageState({ path: authFile(role) });
+    if (role === "admin") {
+      // Back-compat: responsive-baseline specs read this exact path.
+      await context.storageState({ path: "e2e/.auth/baseline-admin.json" });
+    }
+    await context.close();
   }
-  await page.goto("/hu/login");
-  await page.locator("input[type='email']").waitFor({ state: "visible" });
-  await page.locator("input[type='email']").fill("admin@condo.local");
-  await page.locator("input[type='password']").fill("password123");
-  await page.locator("input[type='password']").press("Enter");
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 60_000 });
-  await page.context().storageState({ path: AUTH_FILE });
 });

--- a/e2e/auth.ts
+++ b/e2e/auth.ts
@@ -1,0 +1,41 @@
+import { type Page, expect } from "@playwright/test";
+
+/**
+ * Seeded condo accounts (all password123) keyed by the role we exercise in
+ * E2E. See docs/test-accounts.md / prisma/seed.ts.
+ *   superadmin → platform admin (both buildings)
+ *   admin      → building-1 ADMIN
+ *   board      → building-1 BOARD_MEMBER (chair)
+ *   owner      → building-1 OWNER (resident1)
+ *   tenant     → building-1 TENANT
+ *
+ * Cross-building negative cases (a building-2 user can't reach building-1 data)
+ * are covered at the integration level by tests/integration/isolation-condo.ts
+ * (building-switch membership enforcement), so the E2E set stays building-1.
+ */
+export const CONDO_USERS = {
+  superadmin: "superadmin@condo.local",
+  admin: "admin@condo.local",
+  board: "board@condo.local",
+  owner: "resident1@condo.local",
+  tenant: "tenant1@condo.local",
+} as const;
+
+export type CondoRole = keyof typeof CONDO_USERS;
+
+export const PASSWORD = "password123";
+
+/** storageState path for a role's saved session. */
+export function authFile(role: string): string {
+  return `e2e/.auth/${role}.json`;
+}
+
+/** Log in via the condo login form and wait for the dashboard. */
+export async function loginCondo(page: Page, email: string): Promise<void> {
+  await page.goto("/hu/login");
+  await page.locator("input[type='email']").waitFor({ state: "visible" });
+  await page.locator("input[type='email']").fill(email);
+  await page.locator("input[type='password']").fill(PASSWORD);
+  await page.locator("input[type='password']").press("Enter");
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 60_000 });
+}

--- a/e2e/roles/admin-access.spec.ts
+++ b/e2e/roles/admin-access.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { authFile } from "../auth";
+
+/**
+ * Authorization boundary for the SUPER_ADMIN feature console, driven through
+ * the real app per role. The page (src/app/[locale]/admin/feature-management)
+ * server-guards on hasMinimumRole(role, "SUPER_ADMIN"): non-superadmins (incl.
+ * ADMIN) get an "Access Denied" box; superadmin gets the 3-tab console.
+ *
+ * Read-only: navigation + tab switching only (tabs are client-side state, no
+ * persistence), so this is safe against the shared dev DB.
+ */
+
+const FEATURE_MGMT = "/hu/admin/feature-management";
+
+// Every non-superadmin role must be denied (ADMIN is NOT a platform superadmin).
+for (const role of ["admin", "board", "owner", "tenant"] as const) {
+  test.describe(`${role} is denied the feature console`, () => {
+    test.use({ storageState: authFile(role) });
+
+    test(`${role} → Access Denied, no console tabs`, async ({ page }) => {
+      await page.goto(FEATURE_MGMT);
+      await expect(page.getByText("Access Denied")).toBeVisible();
+      await expect(page.getByRole("tab")).toHaveCount(0);
+    });
+  });
+}
+
+test.describe("superadmin can use the feature console", () => {
+  test.use({ storageState: authFile("superadmin") });
+
+  test("opens the console (no Access Denied)", async ({ page }) => {
+    await page.goto(FEATURE_MGMT);
+    await expect(page.getByText("Access Denied")).toHaveCount(0);
+  });
+
+  test("renders the 3 tabs and they switch", async ({ page }) => {
+    await page.goto(FEATURE_MGMT);
+    const tabs = page.getByRole("tab");
+    await expect(tabs).toHaveCount(3);
+
+    const n = await tabs.count();
+    for (let i = 0; i < n; i++) {
+      await tabs.nth(i).click();
+      await expect(tabs.nth(i)).toHaveAttribute("aria-selected", "true");
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css}\"",
     "test": "vitest",
-    "test:e2e": "playwright test",
+    "test:e2e": "node node_modules/@playwright/test/cli.js test",
     "worker": "tsx watch worker/index.ts",
     "seed:contractors": "tsx prisma/seed-contractors.ts",
     "seed:marketplace-mock": "tsx prisma/seed-marketplace-mock.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
-      testIgnore: ["**/responsive-baseline.spec.ts"],
+      testIgnore: ["**/responsive-baseline.spec.ts", "**/roles/**"],
     },
     /** Phase E lock-in: same e2e suite (excluding the snapshot baseline)
      *  also runs at iPhone-SE viewport (375 × 667) with touch. This is
@@ -36,7 +36,15 @@ export default defineConfig({
         viewport: { width: 375, height: 667 },
         hasTouch: true,
       },
-      testIgnore: ["**/responsive-baseline.spec.ts"],
+      testIgnore: ["**/responsive-baseline.spec.ts", "**/roles/**"],
+    },
+    /** Per-role authorization specs (e2e/roles/) — each spec picks its own
+     *  storageState fixture; depends on `setup` to create them. Desktop only. */
+    {
+      name: "roles",
+      use: { ...devices["Desktop Chrome"] },
+      testMatch: /roles\/.*\.spec\.ts/,
+      dependencies: ["setup"],
     },
     /** Setup project — logs in once and saves the session storageState
      *  to e2e/.auth/baseline-admin.json so the responsive-baseline tests


### PR DESCRIPTION
Part B of the role/building/admin testing effort — a focused **Playwright E2E** layer that drives the real app per role. **Local / on-demand** (not wired into CI; the exhaustive authorization coverage is the CI-gated Vitest suite from Part A, #62).

## What's here
- **e2e/auth.ts + auth.setup.ts** — log in once per seeded role (`superadmin`, `admin`, `board`, `owner`, `tenant`) and save each `storageState` to `e2e/.auth/{role}.json`; still writes `baseline-admin.json` (responsive specs depend on it). Sequential logins to stay under the auth rate limiter.
- **e2e/roles/admin-access.spec.ts** — SUPER_ADMIN feature-console authorization boundary: `admin`/`board`/`owner`/`tenant` → "Access Denied"; `superadmin` → the 3-tab console (tabs render + switch). Read-only.
- **playwright.config.ts** — new `roles` project (`dependencies: ["setup"]`, desktop).
- **package.json** — fix `test:e2e`: `.bin/playwright` symlinks to `playwright-chromium` (no `test` command) so a bare `playwright test` errored; now invokes the `@playwright/test` CLI directly.
- **e2e/README.md** — seed-then-run recipe + the read-only-on-dev-DB constraint + deferred items.

## Verified locally
`npm run test:e2e -- --project=roles` → **7 passed** (setup + 6 role specs).

## Notes / deferred
- Cross-building negatives are covered at the integration level (`isolation-condo.test.ts`).
- Contractor role (separate `/contractor/login` tree) deferred.
- A building-2 owner showed an intermittent dashboard hiccup during fixture setup — flagged for separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)