### PR TITLE
fix(i18n): building.role_OWNER + role_AUDITOR labels (missing-key bug)

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2030,7 +2030,8 @@
     "role_SUPER_ADMIN": "Super Admin",
     "role_ADMIN": "Admin",
     "role_BOARD_MEMBER": "Board Member",
-    "role_RESIDENT": "Resident",
+    "role_OWNER": "Owner",
+    "role_AUDITOR": "Auditor",
     "role_TENANT": "Tenant",
     "noBuilding": "No building selected",
     "switchSuccess": "Switched building successfully"

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2030,7 +2030,8 @@
     "role_SUPER_ADMIN": "Főadminisztrátor",
     "role_ADMIN": "Adminisztrátor",
     "role_BOARD_MEMBER": "Igazgatósági tag",
-    "role_RESIDENT": "Lakástulajdonos",
+    "role_OWNER": "Tulajdonos",
+    "role_AUDITOR": "Számvizsgáló",
     "role_TENANT": "Bérlő",
     "noBuilding": "Nincs kiválasztott épület",
     "switchSuccess": "Épület sikeresen váltva"

--- a/tests/integration/i18n-building-roles.test.ts
+++ b/tests/integration/i18n-building-roles.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { BuildingRole } from "@prisma/client";
+import hu from "@/i18n/hu.json";
+import en from "@/i18n/en.json";
+
+/**
+ * BuildingSwitcher and the profile tab render `t(\`role_${role}\`)` in the
+ * `building` namespace for the user's active role. Every BuildingRole must
+ * therefore have a label in every locale, or next-intl throws MISSING_MESSAGE
+ * at render (which on a cold SSR render could even block the dashboard).
+ *
+ * Regression: role_OWNER / role_AUDITOR were missing after the RESIDENT→OWNER
+ * rename, so every owner/auditor saw the raw key + console errors.
+ */
+describe("i18n — building.role_<ROLE> labels", () => {
+  const locales: Record<string, Record<string, string>> = {
+    hu: hu.building as Record<string, string>,
+    en: en.building as Record<string, string>,
+  };
+
+  it("exist for every BuildingRole in every locale", () => {
+    const missing: string[] = [];
+    for (const role of Object.values(BuildingRole)) {
+      for (const [locale, msgs] of Object.entries(locales)) {
+        const key = `role_${role}`;
+        if (!msgs[key]) missing.push(`${locale}: building.${key}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug (found while investigating the E2E building-2 login)
The `building` i18n namespace was missing **`role_OWNER`** and **`role_AUDITOR`** — leftovers from the Phase-3b `RESIDENT`→`OWNER` rename (only the stale `role_RESIDENT` remained). `BuildingSwitcher` (`building-switcher.tsx:116/196`) and `profile-tab.tsx:143` render `t(\`role_${role}\`)`, so:

- Every **OWNER / AUDITOR** user app-wide (not just building-2) saw the raw key `building.role_OWNER` in the building switcher + profile, plus ~16 `IntlError: MISSING_MESSAGE` console errors per page.
- On a cold SSR render, that next-intl error could block the post-login `/dashboard` redirect — which is exactly the intermittent "b2resident1 fails to reach /dashboard" the E2E fixture setup hit.

## Fix
- Add `role_OWNER` (Tulajdonos / Owner) and `role_AUDITOR` (Számvizsgáló / Auditor) to `hu.json` + `en.json`; drop the dead `role_RESIDENT`.
- **Regression test** (`i18n-building-roles.test.ts`): every `BuildingRole` value has a `building.role_<ROLE>` label in every locale.

## Verified
Reproduced as an owner against a captured dev server (16 errors + raw key), applied the fix, reloaded → **0 console errors**, switcher shows "Tulajdonos".

🤖 Generated with [Claude Code](https://claude.com/claude-code)