### PR TITLE
feat(authz): can() foundation + fix tenant-voting (Phase 0 + 1a)

### DIFF
--- a/src/app/api/voting/votes/[id]/ballot/route.ts
+++ b/src/app/api/voting/votes/[id]/ballot/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
 import { requireRole, hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { createHash } from "crypto";
 import { rateLimitMutationOrRespond } from "@/lib/rate-limit";
@@ -11,7 +12,8 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId, role } = ctx;
     const limited = await rateLimitMutationOrRespond(userId, "ballot:cast", {
       limit: 10,
       windowSeconds: 60,
@@ -138,9 +140,15 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
       unitId = proxyForUnitId;
     } else {
-      // Self-voting
+      // Self-voting — only owners may cast (Tht. § 38); tenants are excluded.
+      if (!allows(ctx, "vote.cast")) {
+        return NextResponse.json(
+          { error: "Only owners can cast a vote" },
+          { status: 403 }
+        );
+      }
       const userUnit = await prisma.unitUser.findFirst({
-        where: { userId, unit: { buildingId } },
+        where: { userId, relationship: "OWNER", unit: { buildingId } },
         select: { unitId: true },
       });
       if (!userUnit) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -21,5 +21,12 @@ export async function requireBuildingContext() {
     userId: user.id,
     buildingId: user.activeBuildingId,
     role: user.activeRole,
+    // ActorContext flags for the ACTIVE building — already hydrated into the
+    // session (auth-options.ts) and re-hydrated on building switch. Enables
+    // can(actor, capability) at call-sites without extra DB lookups.
+    isChair: user.isChair ?? false,
+    isProfessional: user.isProfessional ?? false,
+    ownsAnyUnit: user.ownsAnyUnit ?? false,
+    isAuditor: user.isAuditor ?? false,
   };
 }

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -1,0 +1,57 @@
+import type { BuildingRole } from "@prisma/client";
+import { can, type ActorContext, type Capability } from "./capabilities";
+
+export { can } from "./capabilities";
+export type { ActorContext, Capability } from "./capabilities";
+
+/**
+ * Building-capability authorization, layered on the can() matrix
+ * (src/lib/capabilities.ts). This is the canonical gate for BUILDING-LEVEL
+ * actions — it replaces the legacy `hasMinimumRole` flat hierarchy at those
+ * call-sites.
+ *
+ * STRICT semantics: SUPER_ADMIN is NOT special-cased here — the matrix grants
+ * it no building powers (building impersonation is a separate future flow).
+ *
+ * OUT OF SCOPE (stays on hasMinimumRole / src/lib/rbac.ts): platform & user
+ * governance — users, units, buildings, invitations, audit-logs, the admin
+ * console, contractor CRUD, and the asymmetric escalation checks (an ADMIN
+ * must not grant ADMIN/SUPER_ADMIN). Those are legitimately role-ranked and
+ * have no capability mapping.
+ */
+
+/** The subset of requireBuildingContext()'s result that feeds the matrix. */
+export interface BuildingActor {
+  role: string;
+  isChair?: boolean;
+  ownsAnyUnit?: boolean;
+  isAuditor?: boolean;
+  isProfessional?: boolean;
+}
+
+/** Build a typed ActorContext from a building context. */
+export function actorFrom(ctx: BuildingActor): ActorContext {
+  return {
+    role: ctx.role as BuildingRole,
+    isChair: ctx.isChair,
+    ownsAnyUnit: ctx.ownsAnyUnit,
+    isAuditor: ctx.isAuditor,
+    isProfessional: ctx.isProfessional,
+  };
+}
+
+/** Boolean check — for the inline route style: `if (!allows(ctx, cap)) return 403`. */
+export function allows(ctx: BuildingActor, cap: Capability): boolean {
+  return can(actorFrom(ctx), cap);
+}
+
+/**
+ * Throwing gate — for server actions / DAL functions (mirrors requireRole).
+ * Throws a {status:403}-tagged Error that adminErrorResponse() and the usual
+ * route catch blocks already map to a 403 response.
+ */
+export function requireCapability(ctx: BuildingActor, cap: Capability): void {
+  if (!can(actorFrom(ctx), cap)) {
+    throw Object.assign(new Error("Forbidden"), { status: 403 });
+  }
+}

--- a/tests/integration/role-gates-voting.test.ts
+++ b/tests/integration/role-gates-voting.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * vote.cast gate (Tht. §38 — owners only). Regression for the bug where the
+ * ballot self-cast path accepted ANY unit member: now it requires
+ * can(actor, "vote.cast") (ownsAnyUnit) before a self-cast.
+ */
+
+const { requireBuildingContextMock } = vi.hoisted(() => ({
+  requireBuildingContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireBuildingContext: requireBuildingContextMock,
+  getCurrentUser: vi.fn(),
+  auth: vi.fn(),
+  getSession: vi.fn(),
+  handlers: { GET: vi.fn(), POST: vi.fn() },
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+vi.mock("@/lib/feature-gate", () => ({
+  requireFeature: vi.fn().mockResolvedValue(undefined),
+  FeatureGateError: class FeatureGateError extends Error {},
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimitMutationOrRespond: vi.fn().mockResolvedValue(null),
+}));
+
+const { POST: ballotPOST } = await import(
+  "@/app/api/voting/votes/[id]/ballot/route"
+);
+
+beforeEach(() => requireBuildingContextMock.mockReset());
+
+async function openVote() {
+  const { building } = await makeBuilding();
+  const creator = await makeUser({
+    buildingId: building.id,
+    role: "BOARD_MEMBER",
+  });
+  const vote = await prisma.vote.create({
+    data: {
+      buildingId: building.id,
+      title: "Test vote",
+      description: "d",
+      voteType: "YES_NO",
+      majorityType: "SIMPLE_MAJORITY",
+      isSecret: false,
+      status: "OPEN",
+      quorumRequired: 0.5,
+      deadline: new Date("2099-12-31"),
+      createdById: creator.id,
+    },
+  });
+  const option = await prisma.voteOption.create({
+    data: { voteId: vote.id, label: "Yes" },
+  });
+  return { building, vote, option };
+}
+
+function castReq(optionId: string) {
+  return new NextRequest("http://test/api/voting/votes/x/ballot", {
+    method: "POST",
+    body: JSON.stringify({ optionId }),
+  });
+}
+
+describe("POST ballot — vote.cast (owners only, Tht. §38)", () => {
+  it("TENANT cannot self-cast (403)", async () => {
+    const { building, vote, option } = await openVote();
+    const tenant = await makeUser({ buildingId: building.id, role: "TENANT" });
+    requireBuildingContextMock.mockResolvedValue({
+      userId: tenant.id,
+      buildingId: building.id,
+      role: "TENANT",
+      ownsAnyUnit: false,
+    });
+    const res = await ballotPOST(castReq(option.id), {
+      params: Promise.resolve({ id: vote.id }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("OWNER passes the vote.cast gate (not 403)", async () => {
+    const { building, vote, option } = await openVote();
+    const owner = await makeUser({ buildingId: building.id, role: "OWNER" });
+    requireBuildingContextMock.mockResolvedValue({
+      userId: owner.id,
+      buildingId: building.id,
+      role: "OWNER",
+      ownsAnyUnit: true,
+    });
+    // No owned unit row seeded → the gate passes, then the unit lookup 400s.
+    // A 403 would mean the gate wrongly blocked an owner.
+    const res = await ballotPOST(castReq(option.id), {
+      params: Promise.resolve({ id: vote.id }),
+    });
+    expect(res.status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
First slice of the `hasMinimumRole` → `can()` migration (plan approved). Foundation + the one confirmed compliance bug.

## Phase 0 — foundation
- **`requireBuildingContext()`** now returns the ActorContext flags already hydrated in the session: `isChair`, `ownsAnyUnit`, `isAuditor`, `isProfessional` (no DB/schema change).
- **`src/lib/authz.ts`** — `actorFrom()`, `allows(ctx, cap)` (inline-return style), `requireCapability(ctx, cap)` (throwing style), over the `can()` matrix. **Strict**: SUPER_ADMIN is not special-cased. Documents the boundary: platform/user-management gates stay on `hasMinimumRole`.

## Phase 1a — fix tenant-voting (Tht. §38)
The ballot self-cast accepted **any** unit member. Now it requires `can(actor, "vote.cast")` (`ownsAnyUnit`) and scopes the unit lookup to `relationship: "OWNER"`.
- Test: `role-gates-voting.test.ts` — TENANT self-cast → 403; OWNER passes the gate.

## Verified
`npx tsc --noEmit` clean; full suite **247 tests** green (no regressions — finance/voting routes not yet migrated, so `role-gates-finance` SUPER_ADMIN assertion still holds until Phase 1c).

## Next (separate PRs)
- 1b: representative authority → chair (voting/finance/documents/announcements).
- 1c: `view.building.finance` reads (SUPER_ADMIN → 403; updates `role-gates-finance`), `ticket.assign`, `residents.viewAll`.
- Phase 2: data-shaping flags, RSC pages, sidebar, auditor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)