### PR TITLE
feat(authz): representative actions require chair/ADMIN (Phase 1b)

### DIFF
--- a/src/app/actions/documents.ts
+++ b/src/app/actions/documents.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { requireNotFrozen } from "@/lib/frozen-check";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
@@ -29,8 +29,9 @@ interface CreateDocumentInput {
 
 export async function createDocument(input: CreateDocumentInput): Promise<ActionResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "document.publish.public");
     await requireNotFrozen(buildingId);
 
     const {

--- a/src/app/actions/finance.ts
+++ b/src/app/actions/finance.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireRole, hasMinimumRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { requireNotFrozen } from "@/lib/frozen-check";
 import { requireFeature } from "@/lib/feature-gate";
 import { createAuditLog } from "@/lib/audit";
@@ -24,8 +25,9 @@ const MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
 
 export async function importCharges(rows: ImportRow[]): Promise<ImportResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "manage.budget");
     await requireNotFrozen(buildingId);
     await requireFeature(buildingId, "finance");
 

--- a/src/app/actions/voting.ts
+++ b/src/app/actions/voting.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { requireFeature } from "@/lib/feature-gate";
 import { createAuditLog } from "@/lib/audit";
 import { notify, NotificationType } from "@/lib/notifications";
@@ -28,8 +28,9 @@ interface CreateVoteInput {
 
 export async function createVote(input: CreateVoteInput): Promise<ActionResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "vote.start");
     await requireFeature(buildingId, "voting");
 
     const { title, description, voteType, isSecret, majorityType, quorumRequired, deadline, meetingId, options } = input;
@@ -104,8 +105,9 @@ export async function saveMinutes(
   minutes: string
 ): Promise<ActionResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "vote.editMinutes");
     await requireFeature(buildingId, "voting");
 
     const meeting = await prisma.meeting.findUnique({
@@ -159,8 +161,9 @@ export async function signMeetingMinutes(
   signatureRole: MinutesSignatureRoleInput,
 ): Promise<ActionResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "vote.editMinutes");
     await requireFeature(buildingId, "voting");
 
     const meeting = await prisma.meeting.findUnique({

--- a/src/app/api/communication/emergency/route.ts
+++ b/src/app/api/communication/emergency/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { publishToBuilding } from "@/lib/communication-bus";
 import { rateLimitMutationOrRespond } from "@/lib/rate-limit";
@@ -16,8 +16,9 @@ interface EmergencyBody {
  */
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    if (!hasMinimumRole(role, "BOARD_MEMBER")) {
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    if (!allows(ctx, "announcement.publish")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     // Tight: emergency broadcasts go to every resident; abuse is high-cost.

--- a/src/app/api/documents/[id]/pin/route.ts
+++ b/src/app/api/documents/[id]/pin/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { documentPinToggled } from "@/lib/documents/events";
 
@@ -9,9 +9,10 @@ type RouteContext = { params: Promise<{ id: string }> };
 /** Toggle isPinned on a Document. Board+ only. */
 export async function POST(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
-    if (!hasMinimumRole(role, "BOARD_MEMBER")) {
+    if (!allows(ctx, "document.publish.public")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireRole, hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { documentUpdated, documentDeleted } from "@/lib/documents/events";
 
@@ -55,11 +56,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "document.publish.public")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/documents/[id]/versions/route.ts
+++ b/src/app/api/documents/[id]/versions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { documentVersionCreated } from "@/lib/documents/events";
 
@@ -10,11 +10,10 @@ type RouteContext = {
 
 export async function POST(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "document.publish.public")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole, hasMinimumRole } from "@/lib/rbac";
+import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { Prisma, DocumentVisibility } from "@prisma/client";
 import { documentCreated } from "@/lib/documents/events";
@@ -149,11 +150,10 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "document.publish.public")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/voting/meetings/[id]/attendance/route.ts
+++ b/src/app/api/voting/meetings/[id]/attendance/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { calculateMeetingQuorum } from "@/lib/voting/quorum";
 
@@ -98,7 +98,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
  */
 export async function POST(request: NextRequest, context: RouteContext) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -109,9 +110,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "vote.start")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -166,7 +165,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
  */
 export async function DELETE(request: NextRequest, context: RouteContext) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -177,9 +177,7 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "vote.start")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/voting/meetings/[id]/minutes/route.ts
+++ b/src/app/api/voting/meetings/[id]/minutes/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { meetingMinutesUpdated } from "@/lib/voting/events";
 
@@ -9,7 +9,8 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -20,9 +21,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "vote.editMinutes")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/voting/meetings/[id]/route.ts
+++ b/src/app/api/voting/meetings/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { calculateMeetingQuorum } from "@/lib/voting/quorum";
 import { meetingUpdated, meetingDeleted } from "@/lib/voting/events";
@@ -56,7 +56,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -67,9 +68,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "vote.start")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -115,7 +114,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
 export async function DELETE(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -126,9 +126,7 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "vote.start")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/voting/meetings/route.ts
+++ b/src/app/api/voting/meetings/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { meetingCreated } from "@/lib/voting/events";
 
@@ -84,7 +84,8 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -95,9 +96,7 @@ export async function POST(request: NextRequest) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "vote.start")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/voting/votes/[id]/route.ts
+++ b/src/app/api/voting/votes/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { calculateQuorum, calculateResults, calculateMeetingQuorum, calculateVoteResult } from "@/lib/voting/quorum";
 import { voteUpdated } from "@/lib/voting/events";
@@ -116,7 +116,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -127,9 +128,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    if (!allows(ctx, "vote.start")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/voting/votes/route.ts
+++ b/src/app/api/voting/votes/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { VoteStatus } from "@prisma/client";
 import { votingQueue } from "@/lib/queue";
@@ -111,7 +111,8 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId, role } = ctx;
 
     try {
       await requireFeature(buildingId, "voting");
@@ -122,9 +123,8 @@ export async function POST(request: NextRequest) {
       throw err;
     }
 
-    try {
-      await requireRole(role, "BOARD_MEMBER");
-    } catch {
+    // Starting a vote is representative authority (Tht. §43): chair or ADMIN.
+    if (!allows(ctx, "vote.start")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/tests/integration/role-gates-representative.test.ts
+++ b/tests/integration/role-gates-representative.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { BuildingRole } from "@prisma/client";
+
+/**
+ * Representative-authority enforcement (Tht. §43): starting a vote requires the
+ * CHAIR (BOARD_MEMBER + isChair) or ADMIN — a plain board member is no longer
+ * enough. Locks the can()-based gate at the route layer (the create-vote POST
+ * checks vote.start before parsing the body, so an empty body suffices).
+ */
+
+const { requireBuildingContextMock } = vi.hoisted(() => ({
+  requireBuildingContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireBuildingContext: requireBuildingContextMock,
+  getCurrentUser: vi.fn(),
+  auth: vi.fn(),
+  getSession: vi.fn(),
+  handlers: { GET: vi.fn(), POST: vi.fn() },
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+vi.mock("@/lib/feature-gate", () => ({
+  requireFeature: vi.fn().mockResolvedValue(undefined),
+  FeatureGateError: class FeatureGateError extends Error {},
+}));
+
+const { POST: createVotePOST } = await import("@/app/api/voting/votes/route");
+
+beforeEach(() => requireBuildingContextMock.mockReset());
+
+function ctxFor(role: BuildingRole, isChair = false) {
+  requireBuildingContextMock.mockResolvedValue({
+    userId: "u1",
+    buildingId: "b1",
+    role,
+    isChair,
+    ownsAnyUnit: false,
+    isAuditor: false,
+  });
+}
+
+const emptyReq = () =>
+  new NextRequest("http://test/api/voting/votes", { method: "POST", body: "{}" });
+
+describe("representative authority — create vote (vote.start)", () => {
+  it("denies a non-chair BOARD_MEMBER (403)", async () => {
+    ctxFor("BOARD_MEMBER", false);
+    expect((await createVotePOST(emptyReq())).status).toBe(403);
+  });
+
+  it("denies an OWNER (403)", async () => {
+    ctxFor("OWNER", false);
+    expect((await createVotePOST(emptyReq())).status).toBe(403);
+  });
+
+  it("allows the chair (BOARD_MEMBER + isChair) past the gate", async () => {
+    ctxFor("BOARD_MEMBER", true);
+    expect((await createVotePOST(emptyReq())).status).not.toBe(403);
+  });
+
+  it("allows ADMIN past the gate", async () => {
+    ctxFor("ADMIN", false);
+    expect((await createVotePOST(emptyReq())).status).not.toBe(403);
+  });
+});


### PR DESCRIPTION
Phase 1b of the `hasMinimumRole` → `can()` migration. Representative-authority hard gates now require the **chair (BOARD_MEMBER + isChair) or ADMIN** per Tht. §43, instead of any board member.

## Migrated (14 files)
- **Voting** → `vote.start` (create/update/delete vote, meetings, attendance) and `vote.editMinutes` (save/sign minutes): voting routes + `src/app/actions/voting.ts`.
- **Documents** → `document.publish.public` (publish/upload/version/pin/metadata).
- **Finance** → `manage.budget` (bulk charge import).
- **Announcements** → `announcement.publish` (emergency broadcast).

Pattern: routes `if (!allows(ctx, cap)) return 403`; actions/DAL `requireCapability(ctx, cap)`. **Untouched** (by design): ADMIN/SUPER_ADMIN gates, finance *reads*, and data-shaping `isBoardPlus` flags (later phases). No invoice functions exist in the codebase, so `approve.invoice` had no call-sites.

## Behavior change
Non-chair board members lose representative powers (the intended legal model). Seeded board users are chairs, so demo data is unaffected.

## Verified
New `role-gates-representative.test.ts`: non-chair BOARD_MEMBER + OWNER → 403; chair + ADMIN pass. Full suite **251 green**, tsc + lint clean.

## Next
- 1c: `view.building.finance` reads (SUPER_ADMIN → 403; flips `role-gates-finance` assertion), `ticket.assign`, `residents.viewAll`.
- Phase 2: data-shaping flags, RSC pages, sidebar, auditor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)