### PR TITLE
feat(authz): finance gates → can() (Phase 1c)

### DIFF
--- a/src/app/api/finance/accounts/route.ts
+++ b/src/app/api/finance/accounts/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { listBuildingAccounts } from "@/lib/finance-dal";
 
 export async function GET() {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "finance");
@@ -20,7 +21,7 @@ export async function GET() {
       throw err;
     }
 
-    if (!hasMinimumRole(role, "BOARD_MEMBER")) {
+    if (!allows(ctx, "view.building.finance")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/finance/budget/route.ts
+++ b/src/app/api/finance/budget/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import {
   getBuildingBudgetForYear,
   findExpenseAccountIdsInBuilding,
@@ -25,7 +25,7 @@ async function gateBoard() {
     }
     throw err;
   }
-  if (!hasMinimumRole(ctx.role, "BOARD_MEMBER")) {
+  if (!allows(ctx, "view.building.finance")) {
     return {
       ok: false as const,
       res: NextResponse.json({ error: "Forbidden" }, { status: 403 }),

--- a/src/app/api/finance/import/route.ts
+++ b/src/app/api/finance/import/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { Prisma } from "@prisma/client";
 import { parseCsv } from "@/lib/finance/csv-import";
@@ -80,7 +80,8 @@ async function resolveDefaultAccounts(opts: {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "finance");
@@ -94,7 +95,7 @@ export async function POST(request: NextRequest) {
       throw err;
     }
 
-    if (!hasMinimumRole(role, "BOARD_MEMBER")) {
+    if (!allows(ctx, "manage.budget")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/finance/ledger/export/route.ts
+++ b/src/app/api/finance/ledger/export/route.ts
@@ -1,14 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { requireFeature } from "@/lib/feature-gate";
 import { listLedgerEntriesForExport } from "@/lib/finance-dal";
 
 export async function GET(request: NextRequest) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
-    if (!hasMinimumRole(role, "BOARD_MEMBER")) {
+    if (!allows(ctx, "view.building.finance")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/finance/ledger/route.ts
+++ b/src/app/api/finance/ledger/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import {
   listAllBuildingAccountIds,
   listLedgerEntriesPaginated,
@@ -28,7 +28,7 @@ async function gateBoardFinance() {
     }
     throw err;
   }
-  if (!hasMinimumRole(ctx.role, "BOARD_MEMBER")) {
+  if (!allows(ctx, "view.building.finance")) {
     return {
       ok: false as const,
       res: NextResponse.json({ error: "Forbidden" }, { status: 403 }),

--- a/src/app/api/finance/summary/route.ts
+++ b/src/app/api/finance/summary/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { Prisma } from "@prisma/client";
 import { getBuildingFinancialSummary } from "@/lib/finance-dal";
 
@@ -12,7 +12,8 @@ const toNumber = (d: Prisma.Decimal | null): number =>
 
 export async function GET(request: NextRequest) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "finance");
@@ -26,7 +27,7 @@ export async function GET(request: NextRequest) {
       throw err;
     }
 
-    if (!hasMinimumRole(role, "BOARD_MEMBER")) {
+    if (!allows(ctx, "view.building.finance")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/tests/integration/finance-import-route.test.ts
+++ b/tests/integration/finance-import-route.test.ts
@@ -51,6 +51,7 @@ describe("POST /api/finance/import", () => {
       userId: board.id,
       buildingId: building.id,
       role: "BOARD_MEMBER",
+      isChair: true, // import → manage.budget (representative authority)
     });
 
     const req = new NextRequest("http://test/api/finance/import", {
@@ -101,6 +102,7 @@ describe("POST /api/finance/import", () => {
       userId: board.id,
       buildingId: building.id,
       role: "BOARD_MEMBER",
+      isChair: true, // import → manage.budget (representative authority)
     });
 
     const req = new NextRequest("http://test/api/finance/import", {
@@ -130,6 +132,7 @@ describe("POST /api/finance/import", () => {
       userId: board.id,
       buildingId: building.id,
       role: "BOARD_MEMBER",
+      isChair: true, // import → manage.budget (representative authority)
     });
 
     const req = new NextRequest("http://test/api/finance/import", {

--- a/tests/integration/role-gates-finance.test.ts
+++ b/tests/integration/role-gates-finance.test.ts
@@ -5,14 +5,13 @@ import { prisma } from "@/lib/prisma";
 import { makeBuilding, makeUser } from "../fixtures";
 
 /**
- * Role-denial coverage for the board-only finance reads. Existing finance tests
- * cover the happy path + cross-tenant isolation but never assert that OWNER /
- * TENANT are rejected. These routes gate on hasMinimumRole(role, "BOARD_MEMBER")
- * — the legacy flat hierarchy (src/lib/rbac.ts).
+ * Role gating for the board-only finance reads. These now use
+ * can(actor, "view.building.finance") (BOARD_MEMBER / ADMIN / AUDITOR) — the
+ * legacy hasMinimumRole gate was migrated to the capability matrix.
  *
- * Note: SUPER_ADMIN PASSES this gate (hierarchy level 5 >= 3) even though the
- * can() capability matrix grants SUPER_ADMIN no building-level powers. That's a
- * known legacy↔can() migration gap; we assert the ACTUAL behavior here.
+ * Note: SUPER_ADMIN is now DENIED (403) — the matrix grants it no building
+ * powers (strict can(); building impersonation is a separate future flow).
+ * This is the post-migration behavior (was 200 under the legacy hierarchy).
  */
 
 const { requireBuildingContextMock } = vi.hoisted(() => ({
@@ -50,7 +49,7 @@ const LADDER: { role: BuildingRole; expected: number }[] = [
   { role: "OWNER", expected: 403 },
   { role: "BOARD_MEMBER", expected: 200 },
   { role: "ADMIN", expected: 200 },
-  { role: "SUPER_ADMIN", expected: 200 }, // legacy hierarchy lets superadmin through
+  { role: "SUPER_ADMIN", expected: 403 }, // strict can(): no building powers
 ];
 
 async function asRole(role: BuildingRole) {


### PR DESCRIPTION
Phase 1c of the `hasMinimumRole` → `can()` migration: the finance gates.

## Migrated
- **Reads** (`accounts`, `summary`, `ledger`, `ledger/export`, `budget`) → `view.building.finance` (BOARD_MEMBER / ADMIN / AUDITOR).
- **Bulk import** (POST `/api/finance/import`, a write) → `manage.budget` (chair / ADMIN).

## ⚠️ Behavior change
**SUPER_ADMIN is now denied (403) on building finance** — the strict-`can()` decision (no building powers without an impersonation flow, which is a separate future effort). Updated `role-gates-finance.test.ts`: SUPER_ADMIN `200 → 403`. `finance-import-route` mock now sets `isChair: true` (import is representative authority).

## Verified
Full suite **251 green**, tsc + lint clean. Finance read ladder: TENANT/OWNER/SUPER_ADMIN → 403; BOARD_MEMBER/ADMIN → 200.

## Deferred (next)
- **`ticket.assign`** — the `can()` matrix groups it with representative authority (chair-only). Migrating it makes maintenance assignment/award/publish chair-only, which is a notable ops change worth a deliberate decision — flagging rather than bundling silently.
- **`residents.viewAll`** + the ~50 data-shaping `isBoardPlus` flags, RSC page guards, sidebar, auditor → Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)