### PR TITLE
feat(authz): finance RSC pages → can() (compound entry gate)

### DIFF
--- a/src/app/[locale]/finance/budget/page.tsx
+++ b/src/app/[locale]/finance/budget/page.tsx
@@ -1,5 +1,5 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { getDashboardContext } from "@/lib/dal";
 import { getFinanceBudget } from "@/lib/finance-dal";
 import { redirect } from "next/navigation";
@@ -15,7 +15,7 @@ export default async function FinanceBudgetPage({ params }: Props) {
   setRequestLocale(locale);
 
   const ctx = await getDashboardContext();
-  if (!hasMinimumRole(ctx.role, "BOARD_MEMBER")) {
+  if (!allows(ctx, "view.building.finance")) {
     redirect(`/${locale}/finance`);
   }
 

--- a/src/app/[locale]/finance/invoices/page.tsx
+++ b/src/app/[locale]/finance/invoices/page.tsx
@@ -1,5 +1,5 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { getDashboardContext } from "@/lib/dal";
 import { redirect } from "next/navigation";
 import { FinanceShell } from "@/components/finance/finance-shell";
@@ -13,7 +13,7 @@ export default async function FinanceInvoicesPage({ params }: Props) {
   setRequestLocale(locale);
 
   const ctx = await getDashboardContext();
-  if (!hasMinimumRole(ctx.role, "BOARD_MEMBER")) {
+  if (!allows(ctx, "view.building.finance")) {
     redirect(`/${locale}/finance`);
   }
 

--- a/src/app/[locale]/finance/ledger/page.tsx
+++ b/src/app/[locale]/finance/ledger/page.tsx
@@ -1,5 +1,5 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { getDashboardContext } from "@/lib/dal";
 import { getFinanceLedger } from "@/lib/finance-dal";
 import { redirect } from "next/navigation";
@@ -22,7 +22,7 @@ export default async function FinanceLedgerPage({ params, searchParams }: Props)
   setRequestLocale(locale);
 
   const ctx = await getDashboardContext();
-  if (!hasMinimumRole(ctx.role, "BOARD_MEMBER")) {
+  if (!allows(ctx, "view.building.finance")) {
     redirect(`/${locale}/finance`);
   }
 

--- a/src/app/[locale]/finance/page.tsx
+++ b/src/app/[locale]/finance/page.tsx
@@ -1,7 +1,7 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows, allowsAny } from "@/lib/authz";
 import {
   getDashboardContext,
   getFinanceOverview,
@@ -24,14 +24,14 @@ export default async function FinancePage({ params, searchParams }: Props) {
 
   const ctx = await getDashboardContext();
 
-  // Tht. § 16, § 38 — finance surfaces are owner-only. TENANT has no
-  // common-cost obligation and no own-unit ledger; deny direct-URL
-  // navigation instead of rendering an empty page.
-  if (!hasMinimumRole(ctx.role, "OWNER")) {
+  // Reachable via EITHER right: an owner sees their own-unit finance, a board
+  // member / admin / auditor sees building finance (Tht. § 16, § 38). TENANT
+  // (and SUPER_ADMIN, under strict can()) have neither → redirect.
+  if (!allowsAny(ctx, "view.own.unit.finance", "view.building.finance")) {
     redirect(`/${locale}/dashboard`);
   }
 
-  const isBoardPlus = hasMinimumRole(ctx.role, "BOARD_MEMBER");
+  const isBoardPlus = allows(ctx, "view.building.finance");
 
   // Default tab depends on the role: residents see only "Saját"; board+
   // lands on "Épület" since that's the workspace they spend most time in.

--- a/src/app/[locale]/finance/units/page.tsx
+++ b/src/app/[locale]/finance/units/page.tsx
@@ -1,5 +1,5 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { getDashboardContext } from "@/lib/dal";
 import { getFinanceUnits, type FinanceUnitRow } from "@/lib/finance-dal";
 import { redirect } from "next/navigation";
@@ -19,7 +19,7 @@ export default async function FinanceUnitsPage({ params, searchParams }: Props) 
   setRequestLocale(locale);
 
   const ctx = await getDashboardContext();
-  if (!hasMinimumRole(ctx.role, "BOARD_MEMBER")) {
+  if (!allows(ctx, "view.building.finance")) {
     redirect(`/${locale}/finance`);
   }
 

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -46,6 +46,16 @@ export function allows(ctx: BuildingActor, cap: Capability): boolean {
 }
 
 /**
+ * True if the actor has ANY of the capabilities. For surfaces reachable via
+ * more than one right — e.g. the /finance entry, which an OWNER reaches via
+ * view.own.unit.finance and a board member via view.building.finance.
+ */
+export function allowsAny(ctx: BuildingActor, ...caps: Capability[]): boolean {
+  const actor = actorFrom(ctx);
+  return caps.some((cap) => can(actor, cap));
+}
+
+/**
  * Throwing gate — for server actions / DAL functions (mirrors requireRole).
  * Throws a {status:403}-tagged Error that adminErrorResponse() and the usual
  * route catch blocks already map to a 403 response.

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -685,16 +685,26 @@ export const getAdminDashboard = cache(async (): Promise<AdminDashboardData> => 
 export interface DashboardContext {
   role: string;
   userName: string;
+  // ActorContext flags for the active building, so RSC pages can use can().
+  isChair: boolean;
+  ownsAnyUnit: boolean;
+  isAuditor: boolean;
+  isProfessional: boolean;
 }
 
 export const getDashboardContext = cache(async (): Promise<DashboardContext> => {
-  const { role } = await requireBuildingContext();
+  const { role, isChair, ownsAnyUnit, isAuditor, isProfessional } =
+    await requireBuildingContext();
   // Get user name from session
   const { getCurrentUser } = await import("@/lib/auth");
   const user = await getCurrentUser();
   return {
     role,
     userName: user?.name ?? "",
+    isChair,
+    ownsAnyUnit,
+    isAuditor,
+    isProfessional,
   };
 });
 


### PR DESCRIPTION
Migrates the finance **server pages** off `hasMinimumRole`, solving the `/finance` compound-gate trap you flagged.

## The trap & the fix
`/finance` gated `hasMinimumRole(role, "OWNER")` = "owner **OR** board **OR** admin". A naive single-`can()` swap would lock out a board member who doesn't personally own a unit. So:
- **`allowsAny(ctx, ...caps)`** added to `authz.ts`.
- **`getDashboardContext()`** now returns the actor flags (`isChair`/`ownsAnyUnit`/`isAuditor`/`isProfessional`) so RSC pages can use `can()`.
- **`/finance` entry** → `allowsAny(view.own.unit.finance, view.building.finance)`: owner (own view) **or** board/admin/auditor (building view); TENANT and — under strict `can()` — SUPER_ADMIN redirect to `/dashboard`.
- **`/finance` tab default + sub-pages** (`ledger`/`invoices`/`budget`/`units`) → `view.building.finance`; non-board redirect to `/finance`.

## Verified
- **Live:** owner reaches `/finance`; owner bounced from `/finance/ledger` → `/finance`; end-to-end wiring (session flags → `getDashboardContext` → `can()`) works; no console errors.
- **Board access preserved** (the trap): `rbac-matrix.test.ts` proves `BOARD_MEMBER` has `view.building.finance` regardless of `ownsAnyUnit`, and the compound includes it.
- tsc + lint clean; full suite **251 green**.

## Remaining Phase 2 (documented in memory)
~50 data-shaping `isBoardPlus` flags, sidebar nav (product decision), auditor wiring; plus the `award→vote` compliance feature (the higher-value item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)