### PR TITLE
feat(admin): SUPER_ADMIN read-only user impersonation

### DIFF
--- a/src/app/api/impersonation/exit/route.ts
+++ b/src/app/api/impersonation/exit/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { requireBuildingContext } from "@/lib/auth";
+import { auditFeatureChange, adminErrorResponse } from "@/lib/admin-feature-guard";
+
+/**
+ * POST /api/impersonation/exit — end the current impersonation. Audited as
+ * impersonate.end under the REAL superadmin id. Allowlisted in middleware so it
+ * works even while the read-only block is active. The client then clears the
+ * session (updateSession({ impersonating: null })).
+ */
+export async function POST() {
+  try {
+    const ctx = await requireBuildingContext();
+    if (ctx.impersonating) {
+      await auditFeatureChange({
+        userId: ctx.realUserId, // the REAL superadmin
+        buildingId: ctx.buildingId,
+        action: "impersonate.end",
+        entityType: "User",
+        entityId: ctx.userId, // the impersonated member
+      });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}

--- a/src/app/api/impersonation/members/route.ts
+++ b/src/app/api/impersonation/members/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { requireSuperAdmin, adminErrorResponse } from "@/lib/admin-feature-guard";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/impersonation/members?buildingId=… — the building's active members
+ * for the "view as user" picker. SUPER_ADMIN only.
+ */
+export async function GET(request: Request) {
+  try {
+    await requireSuperAdmin();
+    const buildingId = new URL(request.url).searchParams.get("buildingId");
+    if (!buildingId) {
+      return NextResponse.json({ error: "buildingId required" }, { status: 400 });
+    }
+
+    const members = await prisma.userBuilding.findMany({
+      where: { buildingId, isActive: true },
+      include: { user: { select: { id: true, name: true, email: true } } },
+      orderBy: [{ role: "asc" }, { user: { name: "asc" } }],
+    });
+
+    return NextResponse.json(
+      members.map((m) => ({
+        userId: m.user.id,
+        name: m.user.name,
+        email: m.user.email,
+        role: m.role,
+        isChair: m.isChair,
+      })),
+    );
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}

--- a/src/app/api/impersonation/start/route.ts
+++ b/src/app/api/impersonation/start/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  requireSuperAdmin,
+  adminErrorResponse,
+  auditFeatureChange,
+} from "@/lib/admin-feature-guard";
+import { allows } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+
+const BodySchema = z.object({
+  buildingId: z.string().min(1),
+  userId: z.string().min(1),
+});
+
+/**
+ * POST /api/impersonation/start — begin a read-only impersonation. A SUPER_ADMIN
+ * picks a member of a building; we compute that member's effective flags (the
+ * same way login hydrates them) and return the impersonation context, which the
+ * client writes onto the session. Audited as impersonate.start under the REAL
+ * superadmin id. Read-only is enforced globally by middleware.
+ */
+export async function POST(request: Request) {
+  try {
+    const ctx = await requireSuperAdmin();
+    if (!allows(ctx, "platform.impersonate")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    const { buildingId, userId } = BodySchema.parse(await request.json());
+
+    const membership = await prisma.userBuilding.findUnique({
+      where: { userId_buildingId: { userId, buildingId } },
+      include: {
+        building: { select: { id: true, name: true } },
+        user: { select: { id: true, name: true } },
+      },
+    });
+    if (!membership || !membership.isActive) {
+      return NextResponse.json(
+        { error: "User is not an active member of this building" },
+        { status: 404 },
+      );
+    }
+
+    // Compute the target's flags exactly like login hydration.
+    const [ownsCount, auditCount] = await Promise.all([
+      prisma.unitUser.count({
+        where: { userId, relationship: "OWNER", unit: { buildingId } },
+      }),
+      prisma.auditorMembership.count({
+        where: { userId, buildingId, endedAt: null },
+      }),
+    ]);
+
+    const impersonating = {
+      userId: membership.user.id,
+      userName: membership.user.name ?? "",
+      buildingId: membership.building.id,
+      buildingName: membership.building.name,
+      role: membership.role,
+      isChair: membership.isChair,
+      ownsAnyUnit: ownsCount > 0,
+      isAuditor: auditCount > 0,
+    };
+
+    await auditFeatureChange({
+      userId: ctx.userId, // the REAL superadmin
+      buildingId,
+      action: "impersonate.start",
+      entityType: "User",
+      entityId: userId,
+      newValue: { role: membership.role, buildingId },
+    });
+
+    return NextResponse.json(impersonating);
+  } catch (error) {
+    return adminErrorResponse(error);
+  }
+}

--- a/src/components/admin/building-list.tsx
+++ b/src/components/admin/building-list.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Building2, Plus, Pencil, Trash2, X } from "lucide-react";
 import { useConfirm } from "@/components/shared/confirm-dialog";
+import { ViewAsUserButton } from "./view-as-user-button";
 import type { BuildingsData, BuildingItemData } from "@/lib/dal";
 
 interface BuildingFormData {
@@ -169,6 +170,10 @@ export function BuildingList({ initialData }: BuildingListProps) {
                   </td>
                   <td className="px-6 py-4 text-right">
                     <div className="flex items-center justify-end gap-2">
+                      <ViewAsUserButton
+                        buildingId={building.id}
+                        buildingName={building.name}
+                      />
                       <button
                         onClick={() => openEdit(building)}
                         className="rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-blue-600 transition-colors"

--- a/src/components/admin/view-as-user-button.tsx
+++ b/src/components/admin/view-as-user-button.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { useSession } from "next-auth/react";
+import { Eye, Search, X, ShieldCheck, Check } from "lucide-react";
+
+interface Member {
+  userId: string;
+  name: string | null;
+  email: string;
+  role: string;
+  isChair: boolean;
+}
+
+/**
+ * Per-building "view as user" entry for the admin buildings list. SUPER_ADMIN
+ * picks a member; we start a read-only impersonation and land on that user's
+ * dashboard. Mirrors the building-switcher session pattern (updateSession +
+ * router). Read-only is enforced server-side (middleware); this is the entry.
+ */
+export function ViewAsUserButton({
+  buildingId,
+  buildingName,
+}: {
+  buildingId: string;
+  buildingName: string;
+}) {
+  const t = useTranslations("impersonation");
+  const tRoles = useTranslations("building");
+  const router = useRouter();
+  const locale = useLocale();
+  const { update: updateSession } = useSession();
+
+  const [open, setOpen] = useState(false);
+  const [members, setMembers] = useState<Member[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<Member | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function openPicker() {
+    setOpen(true);
+    setSelected(null);
+    setQuery("");
+    setMembers(null);
+    const res = await fetch(
+      `/api/impersonation/members?buildingId=${encodeURIComponent(buildingId)}`,
+    );
+    setMembers(res.ok ? await res.json() : []);
+  }
+
+  async function go() {
+    if (!selected || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch("/api/impersonation/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ buildingId, userId: selected.userId }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        await updateSession({ impersonating: data });
+        setOpen(false);
+        router.push(`/${locale}/dashboard`);
+        router.refresh();
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const roleLabel = (role: string) =>
+    tRoles(`role_${role}` as Parameters<typeof tRoles>[0]);
+
+  const filtered = (members ?? []).filter((m) => {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    return (m.name ?? "").toLowerCase().includes(q) || m.email.toLowerCase().includes(q);
+  });
+
+  return (
+    <>
+      <button
+        onClick={openPicker}
+        title={t("viewAsUser")}
+        className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-amber-50 hover:text-amber-700"
+      >
+        <Eye className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 p-4"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+            className="flex max-h-[84vh] w-full max-w-xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl"
+          >
+            <div className="flex items-start justify-between gap-4 border-b border-slate-200 px-6 py-4">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                  {t("viewAsUser")}
+                </div>
+                <h2 className="mt-1 text-lg font-semibold text-slate-900">
+                  {t("pickMember")} — {buildingName}
+                </h2>
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                className="rounded-lg p-1.5 text-slate-400 hover:bg-slate-100"
+                aria-label={t("cancel")}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="flex items-center gap-2 border-b border-slate-100 bg-slate-50 px-6 py-3 text-slate-400">
+              <Search className="h-4 w-4" />
+              <input
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t("searchMembers")}
+                className="flex-1 bg-transparent text-sm text-slate-900 outline-none"
+              />
+            </div>
+
+            <div className="min-h-[200px] flex-1 overflow-y-auto p-2">
+              {members === null ? (
+                <p className="p-6 text-center text-sm text-slate-400">…</p>
+              ) : filtered.length === 0 ? (
+                <p className="p-6 text-center text-sm text-slate-400">{t("noMembers")}</p>
+              ) : (
+                filtered.map((m) => (
+                  <button
+                    key={m.userId}
+                    onClick={() => setSelected(m)}
+                    className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors ${
+                      selected?.userId === m.userId ? "bg-amber-50" : "hover:bg-slate-50"
+                    }`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold text-slate-900">
+                        {m.name ?? m.email}
+                      </div>
+                      <div className="truncate text-xs text-slate-500">{m.email}</div>
+                    </div>
+                    <span className="rounded-md bg-slate-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-600">
+                      {roleLabel(m.role)}
+                    </span>
+                    <span
+                      className={`grid h-5 w-5 place-items-center rounded-full border ${
+                        selected?.userId === m.userId
+                          ? "border-amber-500 bg-amber-500 text-white"
+                          : "border-slate-300 text-transparent"
+                      }`}
+                    >
+                      <Check className="h-3 w-3" />
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4 border-t border-slate-200 px-6 py-4">
+              <div className="flex flex-1 items-center gap-2 text-xs text-slate-600">
+                <ShieldCheck className="h-4 w-4 shrink-0 text-emerald-600" />
+                <span>{t("readOnlyNote")}</span>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setOpen(false)}
+                  className="rounded-lg border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+                >
+                  {t("cancel")}
+                </button>
+                <button
+                  onClick={go}
+                  disabled={!selected || busy}
+                  className="rounded-lg bg-amber-500 px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {selected
+                    ? t("viewAsName", { name: selected.name ?? selected.email })
+                    : t("viewAsUser")}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { TopBar } from "./topbar";
+import { ImpersonationBanner } from "./impersonation-banner";
 
 /** Pages that render standalone (no sidebar / top bar). */
 const standalonePages = ["/login", "/forgot-password", "/reset-password", "/verify-email"];
@@ -69,6 +70,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     >
       <Sidebar />
       <main className="lg:pl-[244px]">
+        <ImpersonationBanner />
         <TopBar />
         <div>{children}</div>
       </main>

--- a/src/components/layout/impersonation-banner.tsx
+++ b/src/components/layout/impersonation-banner.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
+import { UserCog, LogOut } from "lucide-react";
+
+/**
+ * Persistent read-only impersonation banner. Visible on every authed page while
+ * a SUPER_ADMIN is impersonating a member. Names the impersonated user + role +
+ * building, notes the real superadmin is logged, and offers Exit (which audits
+ * impersonate.end + clears the session). Renders nothing when not impersonating.
+ */
+export function ImpersonationBanner() {
+  const t = useTranslations("impersonation");
+  const tRoles = useTranslations("building");
+  const { data: session, update: updateSession } = useSession();
+  const router = useRouter();
+  const [exiting, setExiting] = useState(false);
+
+  const imp = session?.user?.impersonating;
+  if (!imp) return null;
+
+  async function exit() {
+    if (exiting) return;
+    setExiting(true);
+    try {
+      await fetch("/api/impersonation/exit", { method: "POST" });
+      await updateSession({ impersonating: null });
+      router.refresh();
+    } finally {
+      setExiting(false);
+    }
+  }
+
+  const roleLabel = tRoles(`role_${imp.role}` as Parameters<typeof tRoles>[0]);
+
+  return (
+    <div
+      role="alert"
+      className="border-b border-amber-300 bg-amber-100 text-amber-950"
+    >
+      <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-3 px-4 py-2.5 sm:px-6">
+        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-amber-200">
+          <UserCog className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold">
+            {t("viewingAs", {
+              name: imp.userName ?? "",
+              role: roleLabel,
+              building: imp.buildingName ?? "",
+            })}{" "}
+            · <span className="font-bold uppercase">{t("readOnly")}</span>
+          </div>
+          <div className="text-xs text-amber-900/80">
+            {t("loggedInAs", { name: session?.user?.name ?? "superadmin" })}
+          </div>
+        </div>
+        <button
+          onClick={exit}
+          disabled={exiting}
+          className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-slate-900 px-3.5 py-2 text-sm font-bold text-amber-300 hover:opacity-90 disabled:opacity-50"
+        >
+          <LogOut className="h-3.5 w-3.5" />
+          {t("exit")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2025,6 +2025,19 @@
     "previous": "Previous",
     "next": "Next"
   },
+  "impersonation": {
+    "viewAsUser": "View as user",
+    "pickMember": "Choose a member",
+    "searchMembers": "Search by name or email…",
+    "noMembers": "No matches",
+    "readOnlyNote": "Read-only — no changes can be made; the session is logged.",
+    "cancel": "Cancel",
+    "viewAsName": "View as {name}",
+    "viewingAs": "Viewing as {name} ({role}) — {building}",
+    "readOnly": "read-only",
+    "loggedInAs": "Signed in as {name} (superadmin) — all viewing is logged",
+    "exit": "Exit"
+  },
   "building": {
     "switchBuilding": "Switch Building",
     "role_SUPER_ADMIN": "Super Admin",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2025,6 +2025,19 @@
     "previous": "Előző",
     "next": "Következő"
   },
+  "impersonation": {
+    "viewAsUser": "Megtekintés felhasználóként",
+    "pickMember": "Válassz tagot",
+    "searchMembers": "Tag keresése név vagy e-mail szerint…",
+    "noMembers": "Nincs találat",
+    "readOnlyNote": "Csak megtekintés — semmilyen módosítás nem végezhető; a munkamenet naplózott.",
+    "cancel": "Mégse",
+    "viewAsName": "Megtekintés {name}-ként",
+    "viewingAs": "Megtekintés: {name} ({role}) — {building}",
+    "readOnly": "csak olvasható",
+    "loggedInAs": "Bejelentkezve: {name} (superadmin) — minden megtekintés naplózva",
+    "exit": "Kilépés"
+  },
   "building": {
     "switchBuilding": "Épület váltása",
     "role_SUPER_ADMIN": "Főadminisztrátor",

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -352,6 +352,18 @@ export const authOptions = {
           }
           // If no match found, ignore the update (prevents privilege escalation)
         }
+
+        // SUPER_ADMIN read-only impersonation: set/clear the context. The
+        // /api/impersonation endpoints are the real guard (they validate the
+        // target member + compute its flags); here we additionally require the
+        // real role to be SUPER_ADMIN before accepting it onto the token.
+        if ("impersonating" in updateData) {
+          if (updateData.impersonating === null) {
+            token.impersonating = undefined;
+          } else if (updateData.impersonating && token.role === "SUPER_ADMIN") {
+            token.impersonating = updateData.impersonating;
+          }
+        }
       }
 
       return token;
@@ -385,6 +397,8 @@ export const authOptions = {
         session.user.contractorOrgPlan = token.contractorOrgPlan as string | undefined;
         session.user.contractorOrgName = token.contractorOrgName as string | undefined;
         session.user.contractorRole = token.contractorRole as string | undefined;
+        session.user.impersonating =
+          token.impersonating as typeof session.user.impersonating;
       }
       return session;
     },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,17 +16,28 @@ export async function getCurrentUser() {
 export async function requireBuildingContext() {
   const user = await getCurrentUser();
   if (!user) throw new Error("Unauthorized");
-  if (!user.activeBuildingId) throw new Error("No building selected");
+
+  // SUPER_ADMIN read-only impersonation: when active, evaluate authorization AND
+  // data as the impersonated member (their userId, role, flags) so reads return
+  // exactly what that user sees — while keeping the real superadmin id as
+  // `realUserId` for audit. Writes are blocked globally by middleware.
+  const imp = user.impersonating;
+  const buildingId = imp?.buildingId ?? user.activeBuildingId;
+  if (!buildingId) throw new Error("No building selected");
+
   return {
-    userId: user.id,
-    buildingId: user.activeBuildingId,
-    role: user.activeRole,
-    // ActorContext flags for the ACTIVE building — already hydrated into the
-    // session (auth-options.ts) and re-hydrated on building switch. Enables
-    // can(actor, capability) at call-sites without extra DB lookups.
-    isChair: user.isChair ?? false,
-    isProfessional: user.isProfessional ?? false,
-    ownsAnyUnit: user.ownsAnyUnit ?? false,
-    isAuditor: user.isAuditor ?? false,
+    userId: imp?.userId ?? user.id,
+    buildingId,
+    role: imp?.role ?? user.activeRole,
+    // ActorContext flags — already hydrated into the session (auth-options.ts).
+    // Enables can(actor, capability) at call-sites without extra DB lookups.
+    isChair: (imp ? imp.isChair : user.isChair) ?? false,
+    isProfessional: (imp ? false : user.isProfessional) ?? false,
+    ownsAnyUnit: (imp ? imp.ownsAnyUnit : user.ownsAnyUnit) ?? false,
+    isAuditor: (imp ? imp.isAuditor : user.isAuditor) ?? false,
+    /** True when the active context is an impersonation (read-only). */
+    impersonating: !!imp,
+    /** The real superadmin id — equals userId unless impersonating. For audit. */
+    realUserId: user.id,
   };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -71,6 +71,26 @@ function isPublicApiRoute(pathname: string): boolean {
 export default auth((req) => {
   const { pathname } = req.nextUrl;
 
+  // Read-only impersonation safety net: while a SUPER_ADMIN is impersonating a
+  // member (read-only), block EVERY mutating request — API routes AND page
+  // server-action POSTs — regardless of whether the target route has been
+  // migrated to can(). Allow only NextAuth (incl. the session update that exits
+  // impersonation) and the impersonation endpoints themselves.
+  const impersonating = !!(
+    req.auth?.user as { impersonating?: unknown } | undefined
+  )?.impersonating;
+  if (impersonating && req.method !== "GET" && req.method !== "HEAD") {
+    const allowed =
+      pathname.startsWith("/api/auth") ||
+      pathname.startsWith("/api/impersonation");
+    if (!allowed) {
+      return NextResponse.json(
+        { error: "Read-only while impersonating" },
+        { status: 403 },
+      );
+    }
+  }
+
   // API routes
   if (pathname.startsWith("/api")) {
     if (isPublicApiRoute(pathname)) {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -24,6 +24,19 @@ declare module "next-auth" {
     contractorOrgPlan?: string;
     contractorOrgName?: string;
     contractorRole?: string;
+    /** SUPER_ADMIN read-only impersonation context. When set, authorization is
+     *  evaluated as this (impersonated) building member; the real superadmin id
+     *  is preserved separately for audit. Presence ⇒ read-only. */
+    impersonating?: {
+      userId: string;
+      userName?: string;
+      buildingId: string;
+      buildingName?: string;
+      role: string;
+      isChair?: boolean;
+      ownsAnyUnit?: boolean;
+      isAuditor?: boolean;
+    };
   }
 
   interface Session {
@@ -54,6 +67,17 @@ declare module "next-auth" {
       contractorOrgPlan?: string;
       contractorOrgName?: string;
       contractorRole?: string;
+      /** SUPER_ADMIN read-only impersonation context (see User.impersonating). */
+      impersonating?: {
+        userId: string;
+        userName?: string;
+        buildingId: string;
+        buildingName?: string;
+        role: string;
+        isChair?: boolean;
+        ownsAnyUnit?: boolean;
+        isAuditor?: boolean;
+      };
     } & DefaultSession["user"];
   }
 }
@@ -80,5 +104,16 @@ declare module "next-auth/jwt" {
     contractorOrgPlan?: string;
     contractorOrgName?: string;
     contractorRole?: string;
+    /** SUPER_ADMIN read-only impersonation context (see User.impersonating). */
+    impersonating?: {
+      userId: string;
+      userName?: string;
+      buildingId: string;
+      buildingName?: string;
+      role: string;
+      isChair?: boolean;
+      ownsAnyUnit?: boolean;
+      isAuditor?: boolean;
+    };
   }
 }

--- a/tests/integration/impersonation-start.test.ts
+++ b/tests/integration/impersonation-start.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { BuildingRole } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * POST /api/impersonation/start begins a SUPER_ADMIN read-only impersonation.
+ * Guards: non-superadmin → 403; non-member target → 404. On success it returns
+ * the impersonated member's *effective* context (role + flags computed from
+ * their memberships, exactly like login hydration) and writes an
+ * `impersonate.start` audit row under the REAL superadmin id.
+ */
+
+const { requireBuildingContextMock } = vi.hoisted(() => ({
+  requireBuildingContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireBuildingContext: requireBuildingContextMock,
+  getCurrentUser: vi.fn(),
+  auth: vi.fn(),
+  getSession: vi.fn(),
+  handlers: { GET: vi.fn(), POST: vi.fn() },
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const { POST: startPOST } = await import("@/app/api/impersonation/start/route");
+
+beforeEach(() => requireBuildingContextMock.mockReset());
+
+/** The mock requireBuildingContext resolves to a ctx with the given role + id. */
+function asSuperAdmin(userId: string, buildingId: string) {
+  requireBuildingContextMock.mockResolvedValue({
+    userId,
+    buildingId,
+    role: "SUPER_ADMIN" as BuildingRole,
+    isChair: false,
+    isProfessional: false,
+    ownsAnyUnit: false,
+    isAuditor: false,
+    impersonating: false,
+    realUserId: userId,
+  });
+}
+
+function asRole(userId: string, buildingId: string, role: BuildingRole) {
+  requireBuildingContextMock.mockResolvedValue({
+    userId,
+    buildingId,
+    role,
+    isChair: false,
+    isProfessional: false,
+    ownsAnyUnit: false,
+    isAuditor: false,
+    impersonating: false,
+    realUserId: userId,
+  });
+}
+
+function req(body: unknown) {
+  return new Request("http://test/api/impersonation/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/impersonation/start", () => {
+  it("rejects a non-superadmin with 403", async () => {
+    const { building } = await makeBuilding();
+    const sa = await makeUser({ buildingId: building.id, role: "ADMIN" });
+    const member = await makeUser({ buildingId: building.id, role: "OWNER" });
+    asRole(sa.id, building.id, "ADMIN");
+
+    const res = await startPOST(req({ buildingId: building.id, userId: member.id }));
+    expect(res.status).toBe(403);
+  });
+
+  it("404s when the target is not an active member of the building", async () => {
+    const { building } = await makeBuilding();
+    const sa = await makeUser({ buildingId: building.id, role: "SUPER_ADMIN" });
+    const outsider = await makeUser({ buildingId: building.id, role: "OWNER" });
+    // Outsider belongs to `building` but we ask to impersonate them in a
+    // building they are NOT a member of → no UserBuilding row → 404.
+    const { building: otherBuilding } = await makeBuilding();
+    asSuperAdmin(sa.id, building.id);
+
+    const res = await startPOST(
+      req({ buildingId: otherBuilding.id, userId: outsider.id }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the member's effective context and audits impersonate.start", async () => {
+    const { building } = await makeBuilding();
+    const sa = await makeUser({ buildingId: building.id, role: "SUPER_ADMIN" });
+    const member = await makeUser({
+      buildingId: building.id,
+      role: "BOARD_MEMBER",
+      name: "Member One",
+    });
+    asSuperAdmin(sa.id, building.id);
+
+    const res = await startPOST(req({ buildingId: building.id, userId: member.id }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toMatchObject({
+      userId: member.id,
+      userName: "Member One",
+      buildingId: building.id,
+      role: "BOARD_MEMBER",
+      isChair: false,
+      ownsAnyUnit: false,
+      isAuditor: false,
+    });
+
+    const audit = await prisma.auditLog.findFirst({
+      where: { action: "impersonate.start", entityId: member.id },
+    });
+    expect(audit).not.toBeNull();
+    expect(audit?.userId).toBe(sa.id); // logged under the REAL superadmin
+    expect(audit?.buildingId).toBe(building.id);
+  });
+
+  it("reflects ownsAnyUnit when the member owns a unit", async () => {
+    const { building } = await makeBuilding();
+    const sa = await makeUser({ buildingId: building.id, role: "SUPER_ADMIN" });
+    const owner = await makeUser({ buildingId: building.id, role: "OWNER" });
+    const unit = await prisma.unit.create({
+      data: {
+        buildingId: building.id,
+        number: "A1",
+        floor: 1,
+        ownershipShare: "0.1000",
+        size: "55.00",
+      },
+    });
+    await prisma.unitUser.create({
+      data: { unitId: unit.id, userId: owner.id, relationship: "OWNER" },
+    });
+    asSuperAdmin(sa.id, building.id);
+
+    const res = await startPOST(req({ buildingId: building.id, userId: owner.id }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).ownsAnyUnit).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Completes the `hasMinimumRole → can()` authorization migration by adding the one piece it deliberately left out: a way for a platform **SUPER_ADMIN** (who, by design, has *no* building powers) to support a building by **viewing it exactly as one of its members would** — read-only and fully audited.

## How it works

- **Pick a real user, not a role.** From the admin buildings list, "View as user" opens a searchable member picker (role pills, read-only note). The superadmin picks an actual member; we reproduce *their* exact role, flags, **and own-unit data** — not a synthetic role shell.
- **Plumbing.** Impersonation lives in the JWT `impersonating` field, set via the NextAuth `update` trigger (same pattern as building-switch). `requireBuildingContext()` returns the impersonated user's `userId` for data reads, while keeping the real superadmin id as `realUserId` for audit.
- **Read-only safety net.** Middleware blocks **every** mutating request (POST/PATCH/PUT/DELETE) while impersonating — route-agnostic, allowlisting only `/api/auth` and `/api/impersonation`. This is safe to ship even though the `can()` migration isn't 100% complete, because nothing can be written as the impersonated user.
- **Audit.** `impersonate.start` / `impersonate.end` rows are written under the **real** superadmin id, naming *which* user was viewed + role + building.
- **UI.** Persistent amber read-only banner on every authed page while impersonating, with Exit.
- **i18n.** New `impersonation` namespace in `hu` + `en`.

## Verification

- `npx vitest run` — **255 passed** (new integration test: start endpoint guard, 404 non-member, effective-context payload, audit row, `ownsAnyUnit`). tsc + lint clean.
- **Live (Playwright):** superadmin → /admin/buildings → View as `admin@condo.local` → banner shows "Megtekintés: Kovács Mária (Adminisztrátor) — Duna Residence · csak olvasható" → admin dashboard data renders (read works) → `POST /api/buildings` blocked **403 "Read-only while impersonating"** → Exit → banner gone, writes restored → audit rows confirmed in DB (`impersonate.start` + `impersonate.end`, both under the superadmin, naming the viewed user).

## Notes

- No LegalHold infra yet — v1 audits start/end only (7-year hold is a documented future add).
- User-level view is more privacy-sensitive than a role shell — hence the audit captures the specific user; read-only keeps it view-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)