### PR TITLE
feat(voting): deadline auto-close cron + broaden page-facing auth guards

### DIFF
--- a/src/app/api/cron/votes-close/route.ts
+++ b/src/app/api/cron/votes-close/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { voteUpdated } from "@/lib/voting/events";
+import { resolveAwardVote } from "@/lib/marketplace";
+
+export const runtime = "nodejs";
+
+/**
+ * Cron tick: close every OPEN vote whose deadline has passed, and for
+ * contractor-award votes (linkedPublicationId set) run the auto-award —
+ * so the winning bid is awarded even if no board member manually closes
+ * the vote.
+ *
+ * Auth: Bearer CRON_SECRET. Run a few times a day from the system cron /
+ * Vercel Cron (mirror the camera-retention + maintenance-scheduled crons).
+ * Idempotent: only OPEN votes past deadline are touched.
+ */
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET not configured" },
+      { status: 500 },
+    );
+  }
+  if (request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return runTick();
+}
+
+/** Allow POST too — some schedulers prefer POST with an empty body. */
+export async function POST(request: NextRequest) {
+  return GET(request);
+}
+
+async function runTick(): Promise<NextResponse> {
+  const now = new Date();
+  const expired = await prisma.vote.findMany({
+    where: { status: "OPEN", deadline: { lt: now } },
+    select: {
+      id: true,
+      buildingId: true,
+      createdById: true,
+      linkedPublicationId: true,
+    },
+  });
+
+  const closed: string[] = [];
+  const awarded: Array<{ voteId: string; result: unknown }> = [];
+  const errors: Array<{ voteId: string; error: string }> = [];
+
+  for (const v of expired) {
+    await prisma.vote.update({
+      where: { id: v.id },
+      data: { status: "CLOSED" },
+    });
+    // Audit the close under the vote's initiator (no human actor at cron time).
+    await voteUpdated({
+      voteId: v.id,
+      updatedByUserId: v.createdById,
+      buildingId: v.buildingId,
+      oldStatus: "OPEN",
+      newValue: { status: "CLOSED", closedBy: "cron" },
+    });
+    closed.push(v.id);
+
+    if (v.linkedPublicationId) {
+      try {
+        const result = await resolveAwardVote(v.id, v.createdById);
+        awarded.push({ voteId: v.id, result });
+      } catch (err) {
+        // A single award failure must not abort the rest of the tick.
+        console.error(`Auto-award on cron close failed for ${v.id}:`, err);
+        errors.push({ voteId: v.id, error: String(err) });
+      }
+    }
+  }
+
+  return NextResponse.json({
+    ranAt: now.toISOString(),
+    closedCount: closed.length,
+    awardedCount: awarded.length,
+    awarded,
+    errors,
+  });
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -4,7 +4,11 @@ import { cache } from "react";
 import { notFound } from "next/navigation";
 import { Prisma } from "@prisma/client";
 import { requireBuildingContext } from "@/lib/auth";
-import { requirePageContext, requirePageFeature } from "@/lib/page-guard";
+import {
+  requirePageContext,
+  requirePageFeature,
+  requirePageRole,
+} from "@/lib/page-guard";
 import { requireRole, hasMinimumRole } from "@/lib/rbac";
 import { requireFeature } from "@/lib/feature-gate";
 import { prisma } from "@/lib/prisma";
@@ -287,8 +291,8 @@ export interface VotesData {
 }
 
 export const getVotes = cache(async (): Promise<VotesData> => {
-  const { buildingId } = await requireBuildingContext();
-  await requireFeature(buildingId, "voting");
+  const { buildingId } = await requirePageContext();
+  await requirePageFeature(buildingId, "voting");
 
   const limit = 20;
   const where = { buildingId };
@@ -937,8 +941,8 @@ export interface FinanceOverviewData {
 }
 
 export const getFinanceOverview = cache(async (): Promise<FinanceOverviewData> => {
-  const { userId, buildingId, role } = await requireBuildingContext();
-  await requireFeature(buildingId, "finance");
+  const { userId, buildingId, role } = await requirePageContext();
+  await requirePageFeature(buildingId, "finance");
 
   const isBoardPlus = hasMinimumRole(role, "BOARD_MEMBER");
 
@@ -1042,9 +1046,9 @@ export interface BuildingFinanceData {
 }
 
 export const getBuildingFinance = cache(async (): Promise<BuildingFinanceData> => {
-  const { buildingId, role } = await requireBuildingContext();
-  await requireRole(role, "BOARD_MEMBER");
-  await requireFeature(buildingId, "finance");
+  const { buildingId, role } = await requirePageContext();
+  requirePageRole(role, "BOARD_MEMBER");
+  await requirePageFeature(buildingId, "finance");
 
   const currentYear = new Date().getFullYear();
   const fromDate = new Date(`${currentYear}-01-01`);

--- a/src/lib/page-guard.ts
+++ b/src/lib/page-guard.ts
@@ -1,6 +1,7 @@
 import { unauthorized, forbidden } from "next/navigation";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
+import { hasMinimumRole } from "@/lib/rbac";
 
 /**
  * Page-facing auth guards. The shared `requireBuildingContext` /
@@ -38,5 +39,12 @@ export async function requirePageFeature(
       forbidden();
     }
     throw err;
+  }
+}
+
+/** Renders the 403 page when the role is below `minimumRole`. */
+export function requirePageRole(role: string, minimumRole: string): void {
+  if (!hasMinimumRole(role, minimumRole)) {
+    forbidden();
   }
 }

--- a/tests/integration/page-guard.test.ts
+++ b/tests/integration/page-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * The page-facing guards translate the shared (API+page) auth/feature/role
+ * helpers' throws into Next's unauthorized() (401) / forbidden() (403)
+ * control-flow signals, which render the dedicated pages. Next tags those
+ * with digest "NEXT_HTTP_ERROR_FALLBACK;401" / ";403". In the real app (with
+ * experimental.authInterrupts enabled) that digest renders the dedicated page;
+ * under vitest the config isn't loaded, so the same functions throw a guard
+ * error naming themselves ("unauthorized()" / "forbidden()") — either way the
+ * assertion confirms the right interrupt was invoked.
+ */
+
+const { requireBuildingContextMock, requireFeatureMock } = vi.hoisted(() => ({
+  requireBuildingContextMock: vi.fn(),
+  requireFeatureMock: vi.fn(),
+}));
+
+class FakeFeatureGateError extends Error {}
+
+vi.mock("@/lib/auth", () => ({
+  requireBuildingContext: requireBuildingContextMock,
+}));
+vi.mock("@/lib/feature-gate", () => ({
+  requireFeature: requireFeatureMock,
+  FeatureGateError: FakeFeatureGateError,
+}));
+
+const { requirePageContext, requirePageFeature, requirePageRole } =
+  await import("@/lib/page-guard");
+
+beforeEach(() => {
+  requireBuildingContextMock.mockReset();
+  requireFeatureMock.mockReset();
+});
+
+/** Returns the interrupt signal: Next's digest (real app) or the function's
+ *  guard message (vitest, where authInterrupts config isn't loaded). */
+async function signalOf(fn: () => unknown | Promise<unknown>): Promise<string> {
+  try {
+    await fn();
+    return "(no throw)";
+  } catch (e) {
+    return (e as { digest?: string }).digest ?? (e as Error).message;
+  }
+}
+
+describe("requirePageContext", () => {
+  it("returns the context when authenticated", async () => {
+    requireBuildingContextMock.mockResolvedValue({ userId: "u1", buildingId: "b1", role: "OWNER" });
+    expect(await requirePageContext()).toMatchObject({ userId: "u1" });
+  });
+
+  it("renders 401 when the session is missing", async () => {
+    requireBuildingContextMock.mockRejectedValue(new Error("Unauthorized"));
+    expect(await signalOf(requirePageContext)).toMatch(/401|unauthorized/i);
+  });
+
+  it("rethrows unrelated errors unchanged", async () => {
+    requireBuildingContextMock.mockRejectedValue(new Error("DB down"));
+    expect(await signalOf(requirePageContext)).toBe("DB down");
+  });
+});
+
+describe("requirePageFeature", () => {
+  it("passes when the feature is enabled", async () => {
+    requireFeatureMock.mockResolvedValue(undefined);
+    expect(await signalOf(() => requirePageFeature("b1", "voting"))).toBe("(no throw)");
+  });
+
+  it("renders 403 when the feature is gated", async () => {
+    requireFeatureMock.mockRejectedValue(new FakeFeatureGateError("upgrade"));
+    expect(await signalOf(() => requirePageFeature("b1", "voting"))).toMatch(/403|forbidden/i);
+  });
+});
+
+describe("requirePageRole", () => {
+  it("renders 403 when the role is too low", async () => {
+    expect(await signalOf(() => requirePageRole("TENANT", "BOARD_MEMBER"))).toMatch(/403|forbidden/i);
+  });
+
+  it("passes when the role is sufficient", async () => {
+    expect(await signalOf(() => requirePageRole("ADMIN", "BOARD_MEMBER"))).toBe("(no throw)");
+  });
+});

--- a/tests/integration/votes-close-cron.test.ts
+++ b/tests/integration/votes-close-cron.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  makeBuilding,
+  makeContractorOrg,
+  makeMaintenanceTicket,
+  makePublication,
+  makeBid,
+  makeUser,
+} from "../fixtures";
+
+/**
+ * The votes-close cron closes every OPEN vote past its deadline and, for
+ * contractor-award votes, runs resolveAwardVote — so a winning bid is awarded
+ * even when no board member manually closes the vote. Email dispatch is mocked
+ * to assert the close + award state machine in isolation.
+ */
+
+const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
+vi.mock("@/lib/marketplace/award-notify", () => ({
+  dispatchAwardOutcome: dispatchMock,
+}));
+
+const { createAwardVote } = await import("@/lib/marketplace/award-vote");
+const { GET } = await import("@/app/api/cron/votes-close/route");
+
+const SECRET = "test-cron-secret";
+beforeAll(() => {
+  process.env.CRON_SECRET = SECRET;
+});
+beforeEach(() => dispatchMock.mockReset());
+
+function req(withAuth = true) {
+  return new NextRequest("http://test/api/cron/votes-close", {
+    headers: withAuth ? { authorization: `Bearer ${SECRET}` } : {},
+  });
+}
+
+let unitSeq = 0;
+async function makeUnit(buildingId: string, share: string) {
+  return prisma.unit.create({
+    data: {
+      buildingId,
+      number: `U-${++unitSeq}`,
+      floor: 1,
+      ownershipShare: share,
+      size: "50.00",
+    },
+  });
+}
+
+describe("votes-close cron", () => {
+  it("rejects a request without the CRON_SECRET", async () => {
+    expect((await GET(req(false))).status).toBe(401);
+  });
+
+  it("closes an expired plain vote", async () => {
+    const { building } = await makeBuilding();
+    const user = await makeUser({ buildingId: building.id, role: "BOARD_MEMBER" });
+    const vote = await prisma.vote.create({
+      data: {
+        title: "Régi szavazás",
+        voteType: "YES_NO",
+        status: "OPEN",
+        majorityType: "SIMPLE_MAJORITY",
+        quorumRequired: "0.5",
+        deadline: new Date(Date.now() - 86_400_000), // yesterday
+        buildingId: building.id,
+        createdById: user.id,
+        options: { create: [{ label: "Igen", sortOrder: 0 }, { label: "Nem", sortOrder: 1 }] },
+      },
+    });
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const after = await prisma.vote.findUnique({ where: { id: vote.id } });
+    expect(after?.status).toBe("CLOSED");
+  });
+
+  it("auto-awards an expired, quorate award vote", async () => {
+    const { building } = await makeBuilding();
+    const ticket = await makeMaintenanceTicket({ buildingId: building.id });
+    const pub = await makePublication({ ticketId: ticket.id, buildingId: building.id });
+    const { org: a } = await makeContractorOrg({ name: "A Kft." });
+    const { org: b } = await makeContractorOrg({ name: "B Kft." });
+    const bidA = await makeBid({ publicationId: pub.id, bidderOrgId: a.id, amount: 1_000_000 });
+    await makeBid({ publicationId: pub.id, bidderOrgId: b.id, amount: 2_000_000 });
+    const user = await makeUser({ buildingId: building.id, role: "BOARD_MEMBER" });
+    const meeting = await prisma.meeting.create({
+      data: { title: "KGY", date: new Date(), time: "18:00", buildingId: building.id, createdById: user.id, agenda: [] },
+    });
+    const u1 = await makeUnit(building.id, "0.5000");
+    const u2 = await makeUnit(building.id, "0.5000");
+
+    await createAwardVote({
+      publicationId: pub.id,
+      meetingId: meeting.id,
+      buildingId: building.id,
+      createdByUserId: user.id,
+    });
+    const vote = await prisma.vote.findFirstOrThrow({
+      where: { linkedPublicationId: pub.id },
+      include: { options: true },
+    });
+    const bidOption = vote.options.find((o) => o.bidId === bidA.id)!;
+    // Push the deadline into the past + cast a quorate set of ballots for bid A.
+    await prisma.vote.update({ where: { id: vote.id }, data: { deadline: new Date(Date.now() - 3600_000) } });
+    await prisma.ballot.create({ data: { voteId: vote.id, optionId: bidOption.id, unitId: u1.id, weight: "0.5000" } });
+    await prisma.ballot.create({ data: { voteId: vote.id, optionId: bidOption.id, unitId: u2.id, weight: "0.5000" } });
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.closedCount).toBeGreaterThanOrEqual(1);
+
+    const closed = await prisma.vote.findUnique({ where: { id: vote.id } });
+    expect(closed?.status).toBe("CLOSED");
+    const wonPub = await prisma.marketplacePublication.findUnique({ where: { id: pub.id } });
+    expect(wonPub?.status).toBe("AWARDED");
+    const wonBid = await prisma.marketplaceBid.findUnique({ where: { id: bidA.id } });
+    expect(wonBid?.status).toBe("WON");
+    expect(dispatchMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two follow-ups to the just-merged voting-award (#72) and error-pages (#71) work.

## 1. Deadline auto-close cron (closes a real gap)
Award votes previously only auto-awarded on a **manual** close — if a vote's deadline passed and nobody closed it, the award never fired.

- `GET`/`POST /api/cron/votes-close` (Bearer `CRON_SECRET`, mirrors `camera-retention` + `maintenance-scheduled`). Closes every `OPEN` vote past its deadline and, for award votes, runs `resolveAwardVote` so the winning bid is awarded automatically. Idempotent; a single award failure doesn't abort the tick; the vote initiator is the actor for the close + award audit.
- **Needs a schedule entry** wherever the other crons are scheduled (external scheduler — not tracked in the repo). A few times a day is plenty.

## 2. Broaden the page-facing guards
More pages now render the dedicated 404/403/401 pages instead of a generic 500.

- `page-guard`: added `requirePageRole()` (→ `forbidden()` / 403).
- `getVotes`, `getFinanceOverview`, `getBuildingFinance` now use `requirePageContext` / `requirePageFeature` / `requirePageRole`: unauthenticated → 401, gated feature → 403, sub-board role on building-finance → 403.

## Verification
- **271 tests pass** (10 new): `votes-close` cron (auth, plain-vote close, expired+quorate auto-award) and `page-guard` (each guard routes to the right interrupt). tsc + lint clean.
- Note: the 403/401 **pixels** weren't clicked-through live this round — the Playwright MCP browser temporarily couldn't reach the dev server (curl returns 200, so it's MCP network flakiness, not the app). The path is covered by the page-guard test + the previously live-verified 404 (same `StatusScreen` + `authInterrupts` boundary). The role-based 403 is now easily reproducible: log in as an owner and open `/finance/building`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)