### PR TITLE
feat(voting): bid-card vote options + auto-award result banner

### DIFF
--- a/src/components/voting/active-vote-hero.tsx
+++ b/src/components/voting/active-vote-hero.tsx
@@ -316,17 +316,77 @@ export function ActiveVoteHero({ vote }: Props) {
         )}
 
         <div
-          className="grid gap-2.5 items-stretch"
-          style={{
-            gridTemplateColumns:
-              vote.options.length === 3
-                ? "1fr 1fr 1fr auto"
-                : `repeat(${vote.options.length}, 1fr) auto`,
-          }}
+          className={vote.isAwardVote ? "flex flex-col gap-2.5" : "grid gap-2.5 items-stretch"}
+          style={
+            vote.isAwardVote
+              ? undefined
+              : {
+                  gridTemplateColumns:
+                    vote.options.length === 3
+                      ? "1fr 1fr 1fr auto"
+                      : `repeat(${vote.options.length}, 1fr) auto`,
+                }
+          }
         >
           {vote.options.map((opt, i) => {
-            const tone = toneFor(i);
             const isSelected = picked === opt.id;
+
+            // Contractor-award vote: render each option as a bid card.
+            if (vote.isAwardVote) {
+              const disabled =
+                vote.hasUserCast || vote.userOwnershipShare === 0 || submitting;
+              return (
+                <button
+                  key={opt.id}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => setPicked(opt.id)}
+                  className="transition-all text-left"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "12px",
+                    padding: "14px 16px",
+                    borderRadius: "12px",
+                    border: `1.5px solid ${isSelected ? "var(--color-ochre)" : "color-mix(in srgb, var(--color-bg) 20%, transparent)"}`,
+                    background: isSelected
+                      ? "color-mix(in srgb, var(--color-ochre) 18%, transparent)"
+                      : "transparent",
+                    color: "var(--color-bg)",
+                    cursor:
+                      vote.hasUserCast || vote.userOwnershipShare === 0
+                        ? "not-allowed"
+                        : "pointer",
+                    opacity: vote.userOwnershipShare === 0 ? 0.5 : 1,
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      width: 18,
+                      height: 18,
+                      borderRadius: "50%",
+                      flexShrink: 0,
+                      border: `2px solid ${isSelected ? "var(--color-ochre)" : "color-mix(in srgb, var(--color-bg) 35%, transparent)"}`,
+                      background: isSelected ? "var(--color-ochre)" : "transparent",
+                    }}
+                  />
+                  <span style={{ flex: 1, minWidth: 0 }}>
+                    <span style={{ fontSize: "14px", fontWeight: 700 }}>{opt.label}</span>
+                    <span style={{ display: "block", fontSize: "12px", opacity: 0.7 }}>
+                      {opt.bid ? t("hero.bidEta", { days: opt.bid.etaDays }) : t("hero.bidNone")}
+                    </span>
+                  </span>
+                  {opt.bid && (
+                    <span style={{ fontSize: "15px", fontWeight: 800, whiteSpace: "nowrap" }}>
+                      {new Intl.NumberFormat("hu-HU").format(opt.bid.amount)} Ft
+                    </span>
+                  )}
+                </button>
+              );
+            }
+
+            const tone = toneFor(i);
             const sel = isSelected
               ? tone === "yes"
                 ? { bg: "var(--color-moss-2)", color: "var(--color-ink)", border: "var(--color-moss-2)" }

--- a/src/components/voting/vote-result-card.tsx
+++ b/src/components/voting/vote-result-card.tsx
@@ -88,6 +88,33 @@ export function VoteResultCard({ vote, canClose, onClosed }: VoteResultCardProps
         </span>
       </div>
 
+      {/* Auto-award outcome banner (contractor-award votes) */}
+      {vote.isAwardVote && vote.award && (
+        <div
+          className="mb-3 rounded-lg px-3 py-2.5 text-sm font-medium"
+          style={
+            vote.award.outcome === "AWARDED"
+              ? {
+                  background: "color-mix(in srgb, var(--color-moss) 16%, transparent)",
+                  color: "var(--color-moss)",
+                }
+              : {
+                  background: "color-mix(in srgb, var(--color-ochre) 18%, transparent)",
+                  color: "var(--color-ochre)",
+                }
+          }
+        >
+          {vote.award.outcome === "AWARDED"
+            ? t("awardedBanner", {
+                name: vote.award.winnerLabel ?? "",
+                amount: new Intl.NumberFormat("hu-HU").format(vote.award.winnerAmount ?? 0),
+              })
+            : vote.award.outcome === "NONE"
+              ? t("awardNone")
+              : t("awardNoQuorum")}
+        </div>
+      )}
+
       {/* Stacked bar */}
       {vote.totalWeight > 0 && (
         <div className="mb-3">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1534,7 +1534,9 @@
       "secret": "secret ballot",
       "submit": "Cast",
       "casting": "Casting…",
-      "alreadyCast": "Already cast"
+      "alreadyCast": "Already cast",
+      "bidEta": "Completion: {days} days",
+      "bidNone": "I support none of the bids"
     },
     "ballotErrors": {
       "submitFailed": "Couldn't record your ballot. Please try again."
@@ -1768,6 +1770,9 @@
     "confirmCloseVote": "Are you sure you want to close this vote? No more ballots can be cast after closing.",
     "voteClosed": "Vote closed",
     "voteOpen": "Vote open",
+    "awardedBanner": "Automatically awarded: {name} — {amount} Ft",
+    "awardNone": "“None of these” won — no award. The board can decide again.",
+    "awardNoQuorum": "Not quorate — the vote did not decide.",
     "yourWeight": "Your voting weight",
     "submitVote": "Submit Vote",
     "submitting": "Submitting...",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -1534,7 +1534,9 @@
       "secret": "titkos szavazás",
       "submit": "Leadás",
       "casting": "Leadás…",
-      "alreadyCast": "Már leadtad"
+      "alreadyCast": "Már leadtad",
+      "bidEta": "Vállalt határidő: {days} nap",
+      "bidNone": "Egyik ajánlatot sem támogatom"
     },
     "ballotErrors": {
       "submitFailed": "Most nem sikerült rögzíteni a szavazatod. Próbáld újra."
@@ -1768,6 +1770,9 @@
     "confirmCloseVote": "Biztosan le szeretné zárni a szavazást? A lezárás után nem lehet több szavazatot leadni.",
     "voteClosed": "Szavazás lezárva",
     "voteOpen": "Szavazás nyitva",
+    "awardedBanner": "Automatikusan odaítélve: {name} — {amount} Ft",
+    "awardNone": "„Egyik sem” nyert — nincs odaítélés. A board újra dönthet.",
+    "awardNoQuorum": "Határozatképtelen — a szavazás nem hozott döntést.",
     "yourWeight": "Az Ön szavazati súlya",
     "submitVote": "Szavazat leadása",
     "submitting": "Feldolgozás...",

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -351,6 +351,16 @@ export interface MeetingVoteResult {
   totalWeight: number;
   ballotCount: number;
   passed: boolean | null;
+  /** True when this vote decides a marketplace bid award. */
+  isAwardVote: boolean;
+  /** Auto-award outcome, computed for a CLOSED award vote (else null). */
+  award:
+    | {
+        outcome: "AWARDED" | "NONE" | "NO_QUORUM";
+        winnerLabel: string | null;
+        winnerAmount: number | null;
+      }
+    | null;
 }
 
 export interface MeetingAttendee {
@@ -415,7 +425,10 @@ export const getMeetingDetail = cache(async (id: string): Promise<MeetingDetailD
       },
       votes: {
         include: {
-          options: { orderBy: { sortOrder: "asc" as const } },
+          options: {
+            orderBy: { sortOrder: "asc" as const },
+            include: { bid: { select: { amount: true } } },
+          },
           ballots: { select: { optionId: true, weight: true } },
           _count: { select: { ballots: true } },
         },
@@ -490,6 +503,31 @@ export const getMeetingDetail = cache(async (id: string): Promise<MeetingDetailD
       }
     }
 
+    // Auto-award outcome for a closed contractor-award vote (mirrors
+    // resolveAwardVote: 50% participation quorum, plurality winner with a bid).
+    const isAwardVote = v.linkedPublicationId != null;
+    let award: MeetingVoteResult["award"] = null;
+    if (isAwardVote && v.status === "CLOSED") {
+      const AWARD_QUORUM = 0.5;
+      if (totalBuildingShares <= 0 || totalWeight / totalBuildingShares < AWARD_QUORUM) {
+        award = { outcome: "NO_QUORUM", winnerLabel: null, winnerAmount: null };
+      } else {
+        const top = [...v.options].sort(
+          (a, b) => (optionWeights.get(b.id) ?? 0) - (optionWeights.get(a.id) ?? 0),
+        )[0];
+        const topWeight = top ? (optionWeights.get(top.id) ?? 0) : 0;
+        if (!top || topWeight <= 0 || !top.bid) {
+          award = { outcome: "NONE", winnerLabel: null, winnerAmount: null };
+        } else {
+          award = {
+            outcome: "AWARDED",
+            winnerLabel: top.label,
+            winnerAmount: Number(top.bid.amount),
+          };
+        }
+      }
+    }
+
     return {
       id: v.id,
       title: v.title,
@@ -507,6 +545,8 @@ export const getMeetingDetail = cache(async (id: string): Promise<MeetingDetailD
       totalWeight,
       ballotCount: v._count.ballots,
       passed,
+      isAwardVote,
+      award,
     };
   });
 

--- a/src/lib/voting-dal.ts
+++ b/src/lib/voting-dal.ts
@@ -31,7 +31,15 @@ export interface ActiveVoteData {
   /** Number of units that have cast a ballot. */
   unitsVoted: number;
   totalUnits: number;
-  options: { id: string; label: string; sortOrder: number }[];
+  options: {
+    id: string;
+    label: string;
+    sortOrder: number;
+    /** Set when this is a contractor-award vote option (null for "Egyik sem"). */
+    bid: { amount: number; etaDays: number } | null;
+  }[];
+  /** True when the vote decides a marketplace bid award (options are bid cards). */
+  isAwardVote: boolean;
   /** The current user's combined ownership share across all owned units. */
   userOwnershipShare: number;
   /** Whether the current user has already cast on this vote (for any of their owned units). */
@@ -169,7 +177,10 @@ export const getVotingOverview = cache(async (): Promise<VotingOverviewData> => 
       prisma.vote.findMany({
         where: { buildingId, status: "OPEN", deadline: { gte: now } },
         include: {
-          options: { orderBy: { sortOrder: "asc" } },
+          options: {
+            orderBy: { sortOrder: "asc" },
+            include: { bid: { select: { amount: true, etaDays: true } } },
+          },
           ballots: { select: { weight: true, optionId: true, unitId: true } },
         },
         orderBy: { deadline: "asc" },
@@ -255,10 +266,14 @@ export const getVotingOverview = cache(async (): Promise<VotingOverviewData> => 
       currentSupportPct,
       unitsVoted,
       totalUnits,
+      isAwardVote: activeRow.linkedPublicationId != null,
       options: activeRow.options.map((o) => ({
         id: o.id,
         label: o.label,
         sortOrder: o.sortOrder,
+        bid: o.bid
+          ? { amount: Number(o.bid.amount), etaDays: o.bid.etaDays }
+          : null,
       })),
       userOwnershipShare,
       hasUserCast,


### PR DESCRIPTION
Completes the voting-award UI — design **screens 2 & 4** — by plumbing bid metadata through the voting read models.

> **Stacked on #73** (cron + guards) for a clean diff. Merge #73 first, then retarget this to `main`.

## Screen 2 — bid-card vote options
`getVotingOverview`'s active vote now carries `isAwardVote` + per-option `bid { amount, etaDays }`. `ActiveVoteHero` renders an award vote's options as **bid cards** (contractor name, amount, completion days) with a radio select + an "Egyik sem" card — instead of the yes/no/abstain buttons.

## Screen 4 — auto-award result banner
`getMeetingDetail` / `MeetingVoteResult` gain `isAwardVote` + a computed `award` outcome for closed award votes (`AWARDED` / `NONE` / `NO_QUORUM`, mirroring `resolveAwardVote`'s 50%-quorum + plurality-with-a-bid rule). `VoteResultCard` shows the banner: **"Automatikusan odaítélve: {name} — {amount} Ft"** (emerald) or the no-award / not-quorate states (amber).

i18n hu+en for the new strings.

## Verification
- **271 tests pass**; tsc + lint clean.
- **Live (Playwright), full flow:** `/voting` showed the bid-card options (names, `3 200 000 Ft` / `2 950 000 Ft`, ETA, "Egyik sem", cast button) → seeded a quorate ballot set for one bid → closed the vote → auto-award fired (`awarded: true`) → the meeting result card showed **"Automatikusan odaítélve: Szigetelő Zrt. — 2 950 000 Ft"**. Scaffolding cleaned up after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)