### PR TITLE
feat(voting): auto-award via the BullMQ vote-auto-close worker

### DIFF
--- a/src/lib/marketplace/award-vote.ts
+++ b/src/lib/marketplace/award-vote.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { votingQueue } from "@/lib/queue";
 import { awardBid } from "./bidding";
 import { dispatchAwardOutcome } from "./award-notify";
 
@@ -39,7 +40,7 @@ export async function createAwardVote(input: {
   buildingId: string;
   createdByUserId: string;
 }): Promise<CreateAwardVoteResult> {
-  return prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
     const pub = await tx.marketplacePublication.findUnique({
       where: { id: input.publicationId },
       include: {
@@ -121,8 +122,26 @@ export async function createAwardVote(input: {
       },
     });
 
-    return { ok: true as const, voteId: vote.id };
+    return { ok: true as const, voteId: vote.id, deadline: meeting.date };
   });
+
+  if (result.ok) {
+    // Schedule the deadline auto-close (+ auto-award) the same way the votes
+    // route does, so award votes close at the deadline even with no manual
+    // close. Best-effort — the votes-close cron is the safety net if this fails.
+    try {
+      const delay = Math.max(0, result.deadline.getTime() - Date.now());
+      await votingQueue.add(
+        "vote-auto-close",
+        { voteId: result.voteId },
+        { delay, jobId: `vote-close-${result.voteId}` },
+      );
+    } catch (err) {
+      console.error("Failed to schedule award-vote auto-close:", err);
+    }
+    return { ok: true, voteId: result.voteId };
+  }
+  return result;
 }
 
 export type ResolveAwardVoteResult =

--- a/tests/integration/award-vote.test.ts
+++ b/tests/integration/award-vote.test.ts
@@ -22,6 +22,9 @@ const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
 vi.mock("@/lib/marketplace/award-notify", () => ({
   dispatchAwardOutcome: dispatchMock,
 }));
+vi.mock("@/lib/queue", () => ({
+  votingQueue: { add: vi.fn().mockResolvedValue(undefined) },
+}));
 
 const { createAwardVote, resolveAwardVote } = await import(
   "@/lib/marketplace/award-vote"

--- a/tests/integration/votes-close-cron.test.ts
+++ b/tests/integration/votes-close-cron.test.ts
@@ -21,6 +21,9 @@ const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
 vi.mock("@/lib/marketplace/award-notify", () => ({
   dispatchAwardOutcome: dispatchMock,
 }));
+vi.mock("@/lib/queue", () => ({
+  votingQueue: { add: vi.fn().mockResolvedValue(undefined) },
+}));
 
 const { createAwardVote } = await import("@/lib/marketplace/award-vote");
 const { GET } = await import("@/app/api/cron/votes-close/route");

--- a/worker/processors/voting.ts
+++ b/worker/processors/voting.ts
@@ -1,5 +1,6 @@
 import { Job } from "bullmq";
 import { PrismaClient } from "@prisma/client";
+import { resolveAwardVote } from "../../src/lib/marketplace";
 
 const prisma = new PrismaClient();
 
@@ -10,7 +11,14 @@ export async function processVotingJob(job: Job): Promise<void> {
 
       const vote = await prisma.vote.findUnique({
         where: { id: voteId },
-        select: { id: true, status: true, title: true, deadline: true },
+        select: {
+          id: true,
+          status: true,
+          title: true,
+          deadline: true,
+          linkedPublicationId: true,
+          createdById: true,
+        },
       });
 
       if (!vote) {
@@ -30,6 +38,17 @@ export async function processVotingJob(job: Job): Promise<void> {
       });
 
       console.log(`Vote ${voteId} ("${vote.title}") auto-closed at deadline.`);
+
+      // Contractor-award vote: tally + auto-award the winning bid (or unfreeze
+      // the publication on no-quorum / "none"). Best-effort.
+      if (vote.linkedPublicationId) {
+        try {
+          const outcome = await resolveAwardVote(vote.id, vote.createdById);
+          console.log(`Award vote ${voteId} resolved:`, outcome);
+        } catch (err) {
+          console.error(`Auto-award on close failed for ${voteId}:`, err);
+        }
+      }
 
       // Send notifications to all active users
       const users = await prisma.user.findMany({


### PR DESCRIPTION
## Context — the real scheduler

While wiring the votes-close cron in, I found the app's actual auto-close mechanism: the votes route enqueues a **delayed BullMQ `vote-auto-close` job** (per vote, fires at the deadline) which the worker (`worker/processors/voting.ts`) consumes. That — not a periodic cron — is how votes close on time.

`createAwardVote` (the "Közgyűlés elé visz" path) created the vote directly and **bypassed that enqueue**, so award votes never got the deadline auto-close. That was the real gap behind item #1.

## Change

- **`createAwardVote`** now schedules the same delayed `vote-auto-close` job (`jobId: vote-close-<id>`), mirroring the votes route. Best-effort (try/catch) — a Redis hiccup can't fail the vote creation.
- **`worker/processors/voting.ts`** — after closing an award vote at its deadline, it runs `resolveAwardVote` (auto-award the winning bid, or unfreeze the publication on no-quorum / "none").

Net: award votes now auto-award through the **primary** mechanism (the deadline worker). The `/api/cron/votes-close` endpoint (PR #73) stays as a **redundant, idempotent safety-net sweep** for votes whose delayed job was lost (e.g. a Redis flush).

## Verification
- **271 tests pass**; tsc + lint clean. The two suites that call `createAwardVote` now mock `@/lib/queue` (matching the repo's per-test queue-mock convention).
- The worker step is a thin wrapper over `resolveAwardVote`, which is already covered (auto-award when quorate, "none", below-quorum).

## Note on scheduling
The BullMQ worker is the scheduler — it runs as the `worker` process (`npm run worker` / the worker container), so no external cron entry is needed for the primary path. The optional `votes-close` cron, if you choose to schedule it as a safety net, needs `CRON_SECRET` set and a periodic hit (it isn't in dev `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)