### PR TITLE
feat(authz): extend can() with governance caps + target-arg (Phase A)

### DIFF
--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -1,8 +1,13 @@
 import type { BuildingRole } from "@prisma/client";
-import { can, type ActorContext, type Capability } from "./capabilities";
+import {
+  can,
+  type ActorContext,
+  type Capability,
+  type CapabilityOpts,
+} from "./capabilities";
 
 export { can } from "./capabilities";
-export type { ActorContext, Capability } from "./capabilities";
+export type { ActorContext, Capability, CapabilityOpts } from "./capabilities";
 
 /**
  * Building-capability authorization, layered on the can() matrix
@@ -40,9 +45,14 @@ export function actorFrom(ctx: BuildingActor): ActorContext {
   };
 }
 
-/** Boolean check — for the inline route style: `if (!allows(ctx, cap)) return 403`. */
-export function allows(ctx: BuildingActor, cap: Capability): boolean {
-  return can(actorFrom(ctx), cap);
+/** Boolean check — for the inline route style: `if (!allows(ctx, cap)) return 403`.
+ *  Pass `opts` for relational caps, e.g. `allows(ctx, "users.assignRole", { targetRole })`. */
+export function allows(
+  ctx: BuildingActor,
+  cap: Capability,
+  opts?: CapabilityOpts,
+): boolean {
+  return can(actorFrom(ctx), cap, opts);
 }
 
 /**
@@ -60,8 +70,12 @@ export function allowsAny(ctx: BuildingActor, ...caps: Capability[]): boolean {
  * Throws a {status:403}-tagged Error that adminErrorResponse() and the usual
  * route catch blocks already map to a 403 response.
  */
-export function requireCapability(ctx: BuildingActor, cap: Capability): void {
-  if (!can(actorFrom(ctx), cap)) {
+export function requireCapability(
+  ctx: BuildingActor,
+  cap: Capability,
+  opts?: CapabilityOpts,
+): void {
+  if (!can(actorFrom(ctx), cap, opts)) {
     throw Object.assign(new Error("Forbidden"), { status: 403 });
   }
 }

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -41,7 +41,35 @@ export type Capability =
   | "residents.viewSameStaircase"
   | "platform.impersonate"
   | "platform.featureFlags"
-  | "auditor.readAll";
+  | "auditor.readAll"
+  // ── Governance (app administration, NOT Tht. representative acts). Unlike
+  //    building capabilities, SUPER_ADMIN DOES hold these.
+  | "users.manage"
+  | "users.assignRole"
+  | "units.manage"
+  | "contractor.view"
+  | "contractor.manage"
+  | "platform.subscriptions";
+
+/** Optional relational context for capabilities that compare the actor to a
+ *  target — currently only `users.assignRole` (you may not grant a role at or
+ *  above your own authority). */
+export interface CapabilityOpts {
+  targetRole?: BuildingRole;
+}
+
+/** Governance caps SUPER_ADMIN holds. Building-legal caps are NOT here —
+ *  SUPER_ADMIN gets those only via the impersonation flow. */
+const SUPER_ADMIN_CAPS: ReadonlySet<Capability> = new Set<Capability>([
+  "platform.impersonate",
+  "platform.featureFlags",
+  "platform.subscriptions",
+  "users.manage",
+  "users.assignRole",
+  "units.manage",
+  "contractor.view",
+  "contractor.manage",
+]);
 
 export interface ActorContext {
   role: BuildingRole;
@@ -65,11 +93,15 @@ export interface ActorContext {
   livesAtUnit?: boolean;
 }
 
-export function can(actor: ActorContext, cap: Capability): boolean {
-  // SUPER_ADMIN gets platform caps only — never building-level powers
-  // without explicit impersonation (out of scope, separate plan).
+export function can(
+  actor: ActorContext,
+  cap: Capability,
+  opts?: CapabilityOpts,
+): boolean {
+  // SUPER_ADMIN holds platform + governance caps (app administration) but no
+  // building-legal powers without the explicit impersonation flow.
   if (actor.role === "SUPER_ADMIN") {
-    return cap === "platform.impersonate" || cap === "platform.featureFlags";
+    return SUPER_ADMIN_CAPS.has(cap);
   }
 
   // Representative authority — Tht. § 43. Either the sole közös
@@ -77,6 +109,12 @@ export function can(actor: ActorContext, cap: Capability): boolean {
   // at-most-one-chair-per-building via a partial unique index.
   const hasRepresentativeAuthority =
     actor.role === "BOARD_MEMBER" && actor.isChair === true;
+
+  // Auditors are peers of board members for read access (Tht. § 27(3)).
+  const isBoardLevel =
+    actor.role === "BOARD_MEMBER" ||
+    actor.role === "ADMIN" ||
+    actor.isAuditor === true;
 
   switch (cap) {
     case "manage.budget":
@@ -120,6 +158,32 @@ export function can(actor: ActorContext, cap: Capability): boolean {
 
     case "auditor.readAll":
       return actor.isAuditor === true;
+
+    // ── Governance ───────────────────────────────────────────────────────
+    case "users.manage":
+      // Create/edit/deactivate users, resident permissions, board perms.
+      return actor.role === "ADMIN";
+
+    case "users.assignRole": {
+      // Only ADMIN reaches here (SUPER_ADMIN handled above). An ADMIN may
+      // assign building/resident roles but NOT grant ADMIN or SUPER_ADMIN —
+      // those require a SUPER_ADMIN.
+      if (actor.role !== "ADMIN") return false;
+      const target = opts?.targetRole;
+      return target !== "ADMIN" && target !== "SUPER_ADMIN";
+    }
+
+    case "units.manage":
+    case "contractor.view":
+      // Board-level read/management (auditors included as peers).
+      return isBoardLevel;
+
+    case "contractor.manage":
+      return actor.role === "ADMIN";
+
+    case "platform.subscriptions":
+      // Platform plan overrides — SUPER_ADMIN only (handled above).
+      return false;
 
     default:
       return false;

--- a/tests/lib/capabilities.test.ts
+++ b/tests/lib/capabilities.test.ts
@@ -26,10 +26,17 @@ const REPRESENTATIVE_CAPS: Capability[] = [
 ];
 
 describe("can() — SUPER_ADMIN scoping", () => {
-  it("grants only platform capabilities and nothing else", () => {
+  it("grants platform + governance caps but never building-legal caps", () => {
     const a = actor({ role: "SUPER_ADMIN" });
+    // Platform + governance (app administration).
     expect(can(a, "platform.impersonate")).toBe(true);
     expect(can(a, "platform.featureFlags")).toBe(true);
+    expect(can(a, "platform.subscriptions")).toBe(true);
+    expect(can(a, "users.manage")).toBe(true);
+    expect(can(a, "users.assignRole", { targetRole: "SUPER_ADMIN" })).toBe(true);
+    expect(can(a, "units.manage")).toBe(true);
+    expect(can(a, "contractor.manage")).toBe(true);
+    // Building-legal caps stay false (impersonation flow only).
     expect(can(a, "manage.budget")).toBe(false);
     expect(can(a, "view.building.finance")).toBe(false);
     expect(can(a, "vote.cast")).toBe(false);
@@ -161,5 +168,44 @@ describe("can() — auditor.readAll", () => {
     expect(can(actor({ role: "AUDITOR", isAuditor: true }), "auditor.readAll")).toBe(true);
     expect(can(actor({ role: "OWNER", isAuditor: true }), "auditor.readAll")).toBe(true);
     expect(can(actor({ role: "AUDITOR", isAuditor: false }), "auditor.readAll")).toBe(false);
+  });
+});
+
+describe("can() — governance: users.manage / contractor.manage", () => {
+  it("ADMIN holds users.manage and contractor.manage; board/auditor do not", () => {
+    expect(can(actor({ role: "ADMIN" }), "users.manage")).toBe(true);
+    expect(can(actor({ role: "ADMIN" }), "contractor.manage")).toBe(true);
+    expect(can(actor({ role: "BOARD_MEMBER", isChair: true }), "users.manage")).toBe(false);
+    expect(can(actor({ role: "BOARD_MEMBER", isChair: true }), "contractor.manage")).toBe(false);
+    expect(can(actor({ role: "AUDITOR", isAuditor: true }), "contractor.manage")).toBe(false);
+  });
+});
+
+describe("can() — governance: board-level read (units.manage / contractor.view)", () => {
+  it("BOARD_MEMBER, ADMIN, and auditors get board-level read", () => {
+    for (const cap of ["units.manage", "contractor.view"] as const) {
+      expect(can(actor({ role: "BOARD_MEMBER" }), cap)).toBe(true);
+      expect(can(actor({ role: "ADMIN" }), cap)).toBe(true);
+      expect(can(actor({ role: "OWNER", isAuditor: true }), cap)).toBe(true);
+      expect(can(actor({ role: "OWNER" }), cap)).toBe(false);
+      expect(can(actor({ role: "TENANT" }), cap)).toBe(false);
+    }
+  });
+});
+
+describe("can() — governance: users.assignRole (relational escalation)", () => {
+  it("ADMIN may assign building/resident roles but not ADMIN or SUPER_ADMIN", () => {
+    const adm = actor({ role: "ADMIN" });
+    for (const t of ["BOARD_MEMBER", "AUDITOR", "OWNER", "TENANT"] as const) {
+      expect(can(adm, "users.assignRole", { targetRole: t })).toBe(true);
+    }
+    expect(can(adm, "users.assignRole", { targetRole: "ADMIN" })).toBe(false);
+    expect(can(adm, "users.assignRole", { targetRole: "SUPER_ADMIN" })).toBe(false);
+  });
+
+  it("SUPER_ADMIN may assign any role; lower roles may assign none", () => {
+    expect(can(actor({ role: "SUPER_ADMIN" }), "users.assignRole", { targetRole: "ADMIN" })).toBe(true);
+    expect(can(actor({ role: "BOARD_MEMBER", isChair: true }), "users.assignRole", { targetRole: "OWNER" })).toBe(false);
+    expect(can(actor({ role: "OWNER" }), "users.assignRole", { targetRole: "TENANT" })).toBe(false);
   });
 });


### PR DESCRIPTION
**Phase A of 4** in fully retiring the deprecated `hasMinimumRole`. Purely additive — no call-site changes, no behavior change for existing capabilities. Safe to merge ahead of the rest.

## Why
You asked to move *everything* to `can()` and remove `hasMinimumRole`. A census found ~150 sites: ~104 building-level (existing caps) and ~46 governance (users/escalation, contractor CRUD, admin console, units, board perms) that had no capability yet. This PR adds the missing capabilities + the one relational primitive so the later phases are mechanical.

## What
- **New governance capabilities** (app administration, *not* Tht. representative acts): `users.manage`, `users.assignRole`, `units.manage`, `contractor.view`, `contractor.manage`, `platform.subscriptions`.
- **`can()` target arg** — optional 3rd param `{ targetRole }` for the only relational check, `users.assignRole`: an ADMIN may assign building/resident roles but **not** grant ADMIN/SUPER_ADMIN; a SUPER_ADMIN may assign any. Optional ⇒ existing 2-arg call sites compile unchanged.
- **SUPER_ADMIN** now holds platform + governance caps (`SUPER_ADMIN_CAPS`) but still **no building-legal caps** — app administration works; building powers remain impersonation-only.
- `allows()` / `requireCapability()` forward the opts.

## Verification
- **275 tests pass** (23 in the capabilities matrix suite, incl. new governance + escalation coverage); tsc + lint clean.

## Next
- **B** — migrate ~104 building-level sites to `allows`/`requireCapability`.
- **C** — migrate ~46 governance sites (incl. `users.assignRole` escalation, `use-auth` → client `can()`, `requirePageRole` → `requirePageCapability`).
- **D** — delete `hasMinimumRole`, `ROLE_HIERARCHY`, and the legacy `canManage*` wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)