### PR TITLE
feat(authz): migrate server-side governance gates to can() (Phase C)

### DIFF
--- a/src/app/[locale]/admin/feature-management/page.tsx
+++ b/src/app/[locale]/admin/feature-management/page.tsx
@@ -1,6 +1,6 @@
 import { setRequestLocale } from "next-intl/server";
 import { getCurrentUser } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import {
   getFeatureCatalog,
   getPlanMatrix,
@@ -19,7 +19,7 @@ export default async function FeatureManagementPage({ params }: Props) {
   setRequestLocale(locale);
 
   const user = await getCurrentUser();
-  if (!user || !hasMinimumRole(user.activeRole, "SUPER_ADMIN")) {
+  if (!user || !allows({ role: user.activeRole }, "platform.admin")) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
         <div className="rounded-lg bg-red-50 px-6 py-4 text-center">

--- a/src/app/[locale]/units/page.tsx
+++ b/src/app/[locale]/units/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { getDashboardContext } from "@/lib/dal";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { getUnitsOverview } from "@/lib/units-dal";
 import { UnitsShell } from "@/components/units/units-shell";
 import { UnitsKpiStrip } from "@/components/units/units-kpis";
@@ -28,7 +28,7 @@ export default async function UnitsPage({ params }: Props) {
   // the building's full unit register. Direct-URL navigation by
   // OWNER / TENANT is redirected to the dashboard.
   const ctx = await getDashboardContext();
-  if (!hasMinimumRole(ctx.role, "BOARD_MEMBER")) {
+  if (!allows(ctx, "units.manage")) {
     redirect(`/${locale}/dashboard`);
   }
 

--- a/src/app/actions/board.ts
+++ b/src/app/actions/board.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 
@@ -22,8 +22,9 @@ export async function updateBoardPermission(input: {
   granted: boolean;
 }): Promise<ActionResult> {
   try {
-    const { userId, role } = await requireBuildingContext();
-    if (!hasMinimumRole(role, "ADMIN")) {
+    const ctx = await requireBuildingContext();
+    const { userId } = ctx;
+    if (!allows(ctx, "users.manage")) {
       return { error: "Forbidden — admin only" };
     }
 
@@ -37,8 +38,7 @@ export async function updateBoardPermission(input: {
       return { error: "Membership not found" };
     }
 
-    // Verify the same building scope as the calling admin.
-    const ctx = await requireBuildingContext();
+    // Verify the same building scope as the calling admin (ctx from above).
     if (ub.buildingId !== ctx.buildingId) {
       return { error: "Membership not in active building" };
     }

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -3,7 +3,8 @@
 import { revalidatePath } from "next/cache";
 import crypto from "crypto";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole, hasMinimumRole } from "@/lib/rbac";
+import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import { BuildingRole, UnitRelationship } from "@prisma/client";
@@ -50,10 +51,7 @@ export async function createUser(input: CreateUserInput): Promise<ActionResult> 
       return { error: "Invalid role" };
     }
 
-    if (
-      (role === "SUPER_ADMIN" || role === "ADMIN") &&
-      !hasMinimumRole(activeRole, "SUPER_ADMIN")
-    ) {
+    if (!allows({ role: activeRole }, "users.assignRole", { targetRole: role as BuildingRole })) {
       return { error: "Only SUPER_ADMIN can assign ADMIN or SUPER_ADMIN roles" };
     }
 
@@ -155,10 +153,11 @@ export async function updateUser(id: string, input: UpdateUserInput): Promise<Ac
       if (!Object.values(BuildingRole).includes(input.role as BuildingRole)) {
         return { error: "Invalid role" };
       }
+      // Block changing TO or FROM an elevated role unless the actor may
+      // assign that role (only SUPER_ADMIN may touch ADMIN/SUPER_ADMIN).
       if (
-        (input.role === "SUPER_ADMIN" || input.role === "ADMIN" ||
-         userBuilding.role === "SUPER_ADMIN" || userBuilding.role === "ADMIN") &&
-        !hasMinimumRole(activeRole, "SUPER_ADMIN")
+        !allows({ role: activeRole }, "users.assignRole", { targetRole: input.role as BuildingRole }) ||
+        !allows({ role: activeRole }, "users.assignRole", { targetRole: userBuilding.role })
       ) {
         return { error: "Only SUPER_ADMIN can change ADMIN or SUPER_ADMIN roles" };
       }
@@ -344,7 +343,7 @@ export async function importUsers(rows: ImportRow[]): Promise<ImportResultType> 
         if (!unitId) { errors.push({ row: rowNum, message: `Unit ${unitNumber} not found` }); continue; }
 
         // RBAC: only SUPER_ADMIN can assign ADMIN+
-        if ((role === "SUPER_ADMIN" || role === "ADMIN") && !hasMinimumRole(activeRole, "SUPER_ADMIN")) {
+        if (!allows({ role: activeRole }, "users.assignRole", { targetRole: role as BuildingRole })) {
           errors.push({ row: rowNum, message: "Only SUPER_ADMIN can assign ADMIN roles" });
           continue;
         }

--- a/src/app/api/admin/subscriptions/[id]/plan/route.ts
+++ b/src/app/api/admin/subscriptions/[id]/plan/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 
 /**
@@ -12,9 +12,10 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { userId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId } = ctx;
 
-    if (!hasMinimumRole(role, "SUPER_ADMIN")) {
+    if (!allows(ctx, "platform.subscriptions")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/maintenance/contractors/[id]/route.ts
+++ b/src/app/api/maintenance/contractors/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { getContractorWithStats } from "@/lib/maintenance/contractors";
 
@@ -10,9 +10,9 @@ type RouteContext = {
 
 export async function GET(request: NextRequest, context: RouteContext) {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
-    if (!hasMinimumRole(activeRole, "BOARD_MEMBER")) {
+    if (!allows(ctx, "contractor.view")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -32,9 +32,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
-    if (!hasMinimumRole(activeRole, "ADMIN")) {
+    if (!allows(ctx, "contractor.manage")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -66,9 +66,9 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
 export async function DELETE(request: NextRequest, context: RouteContext) {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
-    if (!hasMinimumRole(activeRole, "ADMIN")) {
+    if (!allows(ctx, "contractor.manage")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/maintenance/contractors/route.ts
+++ b/src/app/api/maintenance/contractors/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
-    if (!hasMinimumRole(activeRole, "BOARD_MEMBER")) {
+    if (!allows(ctx, "contractor.view")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -48,9 +48,9 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
-    if (!hasMinimumRole(activeRole, "ADMIN")) {
+    if (!allows(ctx, "contractor.manage")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/residents/[id]/permissions/route.ts
+++ b/src/app/api/residents/[id]/permissions/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { getResidentPermissions } from "@/lib/residents-dal";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   try {
-    const { role } = await requireBuildingContext();
-    if (!hasMinimumRole(role, "ADMIN")) {
+    const ctx = await requireBuildingContext();
+    if (!allows(ctx, "users.manage")) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     const { id } = await context.params;

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole, hasMinimumRole } from "@/lib/rbac";
+import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import { BuildingRole, UnitRelationship } from "@prisma/client";
@@ -54,7 +55,7 @@ export async function PATCH(
       (role !== undefined && isElevatedRole(role)) ||
       isElevatedRole(existingMembership.role)
     ) {
-      if (!hasMinimumRole(activeRole, "SUPER_ADMIN")) {
+      if (!allows({ role: activeRole }, "users.assignRole", { targetRole: "ADMIN" })) {
         return NextResponse.json(
           {
             error:

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole, hasMinimumRole } from "@/lib/rbac";
+import { requireRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
@@ -158,10 +159,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Only SUPER_ADMIN can assign SUPER_ADMIN or ADMIN roles
-    if (
-      (role === "SUPER_ADMIN" || role === "ADMIN") &&
-      !hasMinimumRole(activeRole, "SUPER_ADMIN")
-    ) {
+    if (!allows({ role: activeRole }, "users.assignRole", { targetRole: role })) {
       return NextResponse.json(
         { error: "Only SUPER_ADMIN can assign ADMIN or SUPER_ADMIN roles" },
         { status: 403 }

--- a/src/lib/admin-feature-guard.ts
+++ b/src/lib/admin-feature-guard.ts
@@ -1,16 +1,17 @@
 import "server-only";
 import { NextResponse } from "next/server";
 import { requireBuildingContext } from "./auth";
-import { hasMinimumRole } from "./rbac";
+import { allows } from "./authz";
 import { prisma } from "./prisma";
 
 /**
- * Asserts the caller is SUPER_ADMIN. Returns the context on success, or throws
- * an error tagged with an HTTP status that {@link adminErrorResponse} maps.
+ * Asserts the caller is a platform admin (SUPER_ADMIN). Returns the context on
+ * success, or throws an error tagged with an HTTP status that
+ * {@link adminErrorResponse} maps.
  */
 export async function requireSuperAdmin() {
   const ctx = await requireBuildingContext();
-  if (!hasMinimumRole(ctx.role, "SUPER_ADMIN")) {
+  if (!allows(ctx, "platform.admin")) {
     throw Object.assign(new Error("Forbidden"), { status: 403 });
   }
   return ctx;

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -50,6 +50,7 @@ export type Capability =
    *  categories, channel-message moderation, resignation acknowledgement,
    *  pending-agenda handling. Distinct from chair-only representative caps. */
   | "board.manage"
+  | "platform.admin"
   | "platform.impersonate"
   | "platform.featureFlags"
   | "auditor.readAll"
@@ -72,6 +73,7 @@ export interface CapabilityOpts {
 /** Governance caps SUPER_ADMIN holds. Building-legal caps are NOT here —
  *  SUPER_ADMIN gets those only via the impersonation flow. */
 const SUPER_ADMIN_CAPS: ReadonlySet<Capability> = new Set<Capability>([
+  "platform.admin",
   "platform.impersonate",
   "platform.featureFlags",
   "platform.subscriptions",

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -7,7 +7,7 @@ import { requireBuildingContext } from "@/lib/auth";
 import {
   requirePageContext,
   requirePageFeature,
-  requirePageRole,
+  requirePageCapability,
 } from "@/lib/page-guard";
 import { requireRole } from "@/lib/rbac";
 import { allows } from "@/lib/authz";
@@ -1092,8 +1092,9 @@ export interface BuildingFinanceData {
 }
 
 export const getBuildingFinance = cache(async (): Promise<BuildingFinanceData> => {
-  const { buildingId, role } = await requirePageContext();
-  requirePageRole(role, "BOARD_MEMBER");
+  const ctx = await requirePageContext();
+  const { buildingId, role } = ctx;
+  requirePageCapability(ctx, "view.building.finance");
   await requirePageFeature(buildingId, "finance");
 
   const currentYear = new Date().getFullYear();

--- a/src/lib/page-guard.ts
+++ b/src/lib/page-guard.ts
@@ -1,7 +1,7 @@
 import { unauthorized, forbidden } from "next/navigation";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows, type BuildingActor, type Capability } from "@/lib/authz";
 
 /**
  * Page-facing auth guards. The shared `requireBuildingContext` /
@@ -42,9 +42,9 @@ export async function requirePageFeature(
   }
 }
 
-/** Renders the 403 page when the role is below `minimumRole`. */
-export function requirePageRole(role: string, minimumRole: string): void {
-  if (!hasMinimumRole(role, minimumRole)) {
+/** Renders the 403 page when the actor lacks `cap`. */
+export function requirePageCapability(ctx: BuildingActor, cap: Capability): void {
+  if (!allows(ctx, cap)) {
     forbidden();
   }
 }

--- a/src/lib/units-dal.ts
+++ b/src/lib/units-dal.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { cache } from "react";
 import { prisma } from "@/lib/prisma";
 import { requireBuildingContext } from "@/lib/auth";
-import { hasMinimumRole } from "@/lib/rbac";
+import { allows } from "@/lib/authz";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -142,8 +142,9 @@ function occupancyOf(
 
 export const getUnitsOverview = cache(
   async (): Promise<UnitsOverviewData> => {
-    const { buildingId, role } = await requireBuildingContext();
-    const isBoardPlus = hasMinimumRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
+    const isBoardPlus = allows(ctx, "units.manage");
 
     const building = await prisma.building.findUnique({
       where: { id: buildingId },
@@ -275,8 +276,9 @@ export const getUnitsOverview = cache(
 
 export const getUnitDetail = cache(
   async (unitId: string): Promise<UnitDetailData | null> => {
-    const { buildingId, role } = await requireBuildingContext();
-    const isBoardPlus = hasMinimumRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
+    const isBoardPlus = allows(ctx, "units.manage");
 
     const unit = await prisma.unit.findUnique({
       where: { id: unitId },

--- a/tests/integration/page-guard.test.ts
+++ b/tests/integration/page-guard.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/feature-gate", () => ({
   FeatureGateError: FakeFeatureGateError,
 }));
 
-const { requirePageContext, requirePageFeature, requirePageRole } =
+const { requirePageContext, requirePageFeature, requirePageCapability } =
   await import("@/lib/page-guard");
 
 beforeEach(() => {
@@ -74,12 +74,12 @@ describe("requirePageFeature", () => {
   });
 });
 
-describe("requirePageRole", () => {
-  it("renders 403 when the role is too low", async () => {
-    expect(await signalOf(() => requirePageRole("TENANT", "BOARD_MEMBER"))).toMatch(/403|forbidden/i);
+describe("requirePageCapability", () => {
+  it("renders 403 when the actor lacks the capability", async () => {
+    expect(await signalOf(() => requirePageCapability({ role: "TENANT" }, "view.boardContext"))).toMatch(/403|forbidden/i);
   });
 
-  it("passes when the role is sufficient", async () => {
-    expect(await signalOf(() => requirePageRole("ADMIN", "BOARD_MEMBER"))).toBe("(no throw)");
+  it("passes when the actor has the capability", async () => {
+    expect(await signalOf(() => requirePageCapability({ role: "ADMIN" }, "view.boardContext"))).toBe("(no throw)");
   });
 });

--- a/tests/lib/capabilities.test.ts
+++ b/tests/lib/capabilities.test.ts
@@ -31,6 +31,7 @@ describe("can() — SUPER_ADMIN scoping", () => {
     // Platform + governance (app administration).
     expect(can(a, "platform.impersonate")).toBe(true);
     expect(can(a, "platform.featureFlags")).toBe(true);
+    expect(can(a, "platform.admin")).toBe(true);
     expect(can(a, "platform.subscriptions")).toBe(true);
     expect(can(a, "users.manage")).toBe(true);
     expect(can(a, "users.assignRole", { targetRole: "SUPER_ADMIN" })).toBe(true);
@@ -185,6 +186,11 @@ describe("can() — board/admin read context", () => {
     expect(can(actor({ role: "ADMIN" }), "view.adminContext")).toBe(true);
     expect(can(actor({ role: "BOARD_MEMBER", isChair: true }), "view.adminContext")).toBe(false);
     expect(can(actor({ role: "SUPER_ADMIN" }), "view.adminContext")).toBe(false);
+  });
+
+  it("platform.admin: super-admin only (ADMIN does not hold it)", () => {
+    expect(can(actor({ role: "ADMIN" }), "platform.admin")).toBe(false);
+    expect(can(actor({ role: "BOARD_MEMBER", isChair: true }), "platform.admin")).toBe(false);
   });
 });
 


### PR DESCRIPTION
**Phase C (server-side).** Migrates the governance `hasMinimumRole` sites onto `can()`. Builds on #76/#77 (merged).

## Changes
- **Admin console**: `requireSuperAdmin` + feature-management page → **`platform.admin`** (new cap); subscription plan override → `platform.subscriptions`.
- **Contractor CRUD**: view → `contractor.view`; create/edit/delete → `contractor.manage`.
- **User governance**: resident permissions + board-permission toggle → `users.manage`.
- **Units**: page redirect + `units-dal` flags → `units.manage`.
- **Role escalation** (users.ts ×3, users routes ×2) → the relational **`users.assignRole` with `{ targetRole }`** — preserves "only SUPER_ADMIN can assign ADMIN/SUPER_ADMIN," including the change-*to-or-from*-elevated-role case (modeled as two `allows` checks on the new + old role).
- **page-guard**: `requirePageRole` → `requirePageCapability`; `getBuildingFinance` uses `view.building.finance`.

## Verification
- **278 tests pass**; tsc + lint clean. Matrix tests cover `platform.admin` and `users.assignRole` escalation.
- After this, the only remaining `hasMinimumRole` *call* is the client hook `use-auth.ts` (+ a comment).

## ⚠️ Two things before Phase D (deletion) — need your input

1. **Sidebar / `use-auth` (client):** the sidebar gates each nav item by a `minimumRole` *tier* (TENANT/OWNER/BOARD_MEMBER/ADMIN). That's genuinely hierarchical UX ("OWNER+ sees this menu," incl. board/admin) and doesn't map cleanly to capabilities without inventing ~10 nav-only caps. Needs a design call (see PR comment / chat).

2. **`requireRole` — newly discovered ~40-site surface.** `requireRole` is `rbac.ts`'s *throwing* sibling, also built on `hasMinimumRole`, used in ~40 places (finance, units, buildings, invitations, reports, dashboard, docs, …). Deleting `hasMinimumRole` (Phase D) **requires migrating `requireRole` too** — it wasn't in the original `hasMinimumRole` census. This is effectively a second Phase-B-sized pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)