### PR TITLE
feat(authz): client nav → capabilities (Phase C2a)

### DIFF
--- a/src/app/[locale]/admin/buildings/page.tsx
+++ b/src/app/[locale]/admin/buildings/page.tsx
@@ -15,7 +15,7 @@ export default async function BuildingsPage({ params }: Props) {
 
   return (
     <RoleGuard
-      role="SUPER_ADMIN"
+      capability="platform.admin"
       fallback={
         <div className="flex min-h-[60vh] items-center justify-center">
           <div className="rounded-lg bg-red-50 px-6 py-4 text-center">

--- a/src/app/[locale]/admin/officer-registry/page.tsx
+++ b/src/app/[locale]/admin/officer-registry/page.tsx
@@ -44,7 +44,7 @@ export default async function OfficerRegistryPage({ params }: Props) {
 
   return (
     <RoleGuard
-      role="SUPER_ADMIN"
+      capability="platform.admin"
       fallback={
         <div className="flex min-h-[60vh] items-center justify-center">
           <div className="rounded-lg bg-red-50 px-6 py-4 text-center">

--- a/src/components/auth/role-guard.tsx
+++ b/src/components/auth/role-guard.tsx
@@ -1,21 +1,22 @@
 "use client";
 
 import { useAuth } from "@/hooks/use-auth";
+import type { Capability } from "@/lib/authz";
 
 interface RoleGuardProps {
-  role: string;
+  capability: Capability;
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
 
-export function RoleGuard({ role, children, fallback = null }: RoleGuardProps) {
-  const { hasRole, isLoading } = useAuth();
+export function RoleGuard({ capability, children, fallback = null }: RoleGuardProps) {
+  const { can, isLoading } = useAuth();
 
   if (isLoading) {
     return null;
   }
 
-  if (!hasRole(role)) {
+  if (!can(capability)) {
     return <>{fallback}</>;
   }
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
 import { useAuth } from "@/hooks/use-auth";
+import type { Capability } from "@/lib/authz";
 import { usePlanFeatures } from "@/hooks/use-plan-features";
 import { useEffect, useState } from "react";
 import { Menu, X } from "lucide-react";
@@ -14,18 +15,19 @@ interface NavItem {
   key: string;
   href: string;
   icon: (props: { className?: string }) => React.ReactNode;
-  minimumRole: string;
+  /** Caps that grant visibility (ANY); omit/empty = visible to everyone. */
+  capabilities?: Capability[];
   featureSlug?: string;
   requiredPlan?: string;
   badgeCount?: number;
   badgeAlert?: boolean;
-  subItems?: { key: string; href: string; minimumRole: string }[];
+  subItems?: { key: string; href: string; capabilities?: Capability[] }[];
 }
 
 interface NavSection {
   label: string;
   items: NavItem[];
-  minimumRole?: string;
+  capabilities?: Capability[];
 }
 
 // ── Inline icons matching the dashboard design exactly ────────────────────
@@ -165,14 +167,14 @@ const sections: NavSection[] = [
   {
     label: "navSection.workshop",
     items: [
-      { key: "dashboard", href: "/dashboard", icon: Icons.dashboard, minimumRole: "TENANT" },
+      { key: "dashboard", href: "/dashboard", icon: Icons.dashboard },
       {
         key: "finance",
         href: "/finance",
         icon: Icons.finance,
-        // Tht. § 16, § 38 — finance is owner-only (TENANT does not pay
-        // common costs and has no own-unit-finance to view).
-        minimumRole: "OWNER",
+        // Tht. § 16, § 38 — finance is owner-only (own-unit finance) or
+        // board/admin (building finance).
+        capabilities: ["view.own.unit.finance", "view.building.finance"],
         featureSlug: "finance",
         requiredPlan: "pro",
       },
@@ -180,8 +182,8 @@ const sections: NavSection[] = [
         key: "voting",
         href: "/voting",
         icon: Icons.voting,
-        // Tht. § 38 — tenants do not vote. Owner-only nav item.
-        minimumRole: "OWNER",
+        // Tht. § 38 — owners vote; board/admin manage. Tenants do not vote.
+        capabilities: ["vote.cast", "view.boardContext"],
         featureSlug: "voting",
         requiredPlan: "pro",
       },
@@ -189,24 +191,22 @@ const sections: NavSection[] = [
         key: "maintenance",
         href: "/maintenance",
         icon: Icons.maintenance,
-        minimumRole: "TENANT",
         featureSlug: "maintenance",
         requiredPlan: "pro",
         subItems: [
-          { key: "maintenanceContractors", href: "/maintenance/contractors", minimumRole: "BOARD_MEMBER" },
-          { key: "maintenanceScheduled", href: "/maintenance/scheduled", minimumRole: "BOARD_MEMBER" },
+          { key: "maintenanceContractors", href: "/maintenance/contractors", capabilities: ["contractor.view"] },
+          { key: "maintenanceScheduled", href: "/maintenance/scheduled", capabilities: ["board.manage"] },
         ],
       },
       {
         key: "communication",
         href: "/communication",
         icon: Icons.communication,
-        minimumRole: "TENANT",
         subItems: [
-          { key: "complaints", href: "/complaints", minimumRole: "TENANT" },
+          { key: "complaints", href: "/complaints" },
         ],
       },
-      { key: "documents", href: "/documents", icon: Icons.documents, minimumRole: "TENANT" },
+      { key: "documents", href: "/documents", icon: Icons.documents },
     ],
   },
   {
@@ -216,23 +216,23 @@ const sections: NavSection[] = [
       // TENANT see their own unit on the dashboard tile, never the full
       // unit ledger. (Tht. § 16, § 38 — owners have legal standing on
       // their own unit, not on the building's full register.)
-      { key: "units", href: "/units", icon: Icons.units, minimumRole: "BOARD_MEMBER" },
-      { key: "residents", href: "/residents", icon: Icons.residents, minimumRole: "TENANT" },
+      { key: "units", href: "/units", icon: Icons.units, capabilities: ["units.manage"] },
+      { key: "residents", href: "/residents", icon: Icons.residents },
     ],
   },
   {
     label: "navSection.platform",
-    minimumRole: "ADMIN",
+    capabilities: ["view.adminContext", "platform.admin"],
     items: [
-      { key: "buildings", href: "/admin/buildings", icon: Icons.buildings, minimumRole: "SUPER_ADMIN" },
+      { key: "buildings", href: "/admin/buildings", icon: Icons.buildings, capabilities: ["platform.admin"] },
       {
         key: "settings",
         href: "/settings",
         icon: Icons.settings,
-        minimumRole: "ADMIN",
+        capabilities: ["view.adminContext"],
         subItems: [
-          { key: "settingsInvitations", href: "/settings/invitations", minimumRole: "ADMIN" },
-          { key: "settingsBilling", href: "/settings/billing", minimumRole: "ADMIN" },
+          { key: "settingsInvitations", href: "/settings/invitations", capabilities: ["users.manage"] },
+          { key: "settingsBilling", href: "/settings/billing", capabilities: ["view.adminContext"] },
         ],
       },
     ],
@@ -248,7 +248,7 @@ export function Sidebar() {
   const t = useTranslations("nav");
   const locale = useLocale();
   const pathname = usePathname();
-  const { hasRole, user } = useAuth();
+  const { canAny, user } = useAuth();
   const { hasFeature, planSlug, isLegacy } = usePlanFeatures();
   // useBuilding is consumed by the inline BuildingSwitcher; no need to read it here.
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -289,11 +289,13 @@ export function Sidebar() {
   const isFeatureAvailable = (item: NavItem) =>
     !item.featureSlug || isLegacy || hasFeature(item.featureSlug);
 
+  const showFor = (caps?: Capability[]) => !caps || caps.length === 0 || canAny(...caps);
+
   const visibleSections = sections
-    .filter((s) => !s.minimumRole || hasRole(s.minimumRole))
+    .filter((s) => showFor(s.capabilities))
     .map((s) => ({
       ...s,
-      items: s.items.filter((i) => hasRole(i.minimumRole)),
+      items: s.items.filter((i) => showFor(i.capabilities)),
     }))
     .filter((s) => s.items.length > 0);
 
@@ -361,7 +363,7 @@ export function Sidebar() {
             const onBranch = isOnBranch(item.href);
             const available = isFeatureAvailable(item);
             const visibleSubItems =
-              item.subItems?.filter((sub) => hasRole(sub.minimumRole)) ?? [];
+              item.subItems?.filter((sub) => showFor(sub.capabilities)) ?? [];
             const planBadge = item.requiredPlan ? PLAN_BADGE[item.requiredPlan] : null;
 
             if (!available) {

--- a/src/components/voting/voting-page.tsx
+++ b/src/components/voting/voting-page.tsx
@@ -59,9 +59,9 @@ interface VotingPageProps {
 export function VotingPage({ initialVotes }: VotingPageProps) {
   const t = useTranslations("voting");
   const tCommon = useTranslations("common");
-  const { hasRole } = useAuth();
+  const { can } = useAuth();
   const router = useRouter();
-  const isBoardPlus = hasRole("BOARD_MEMBER");
+  const isBoardPlus = can("view.boardContext");
 
   const [activeTab, setActiveTab] = useState<"votes" | "meetings">("votes");
   const [votes, setVotes] = useState<VoteSummary[]>(initialVotes.votes as VoteSummary[]);

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,7 +1,13 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { hasMinimumRole } from "@/lib/rbac";
+import {
+  allows,
+  allowsAny,
+  type BuildingActor,
+  type Capability,
+  type CapabilityOpts,
+} from "@/lib/authz";
 
 export function useAuth() {
   const { data: session, status } = useSession();
@@ -10,16 +16,33 @@ export function useAuth() {
   const isAuthenticated = status === "authenticated" && !!session?.user;
   const user = session?.user ?? null;
 
-  function hasRole(minimumRole: string): boolean {
+  // The capability matrix is pure, so it runs client-side too. Build the
+  // actor from the session (the JWT carries the building flags).
+  const actor: BuildingActor = {
+    role: user?.activeRole ?? "TENANT",
+    isChair: user?.isChair,
+    ownsAnyUnit: user?.ownsAnyUnit,
+    isAuditor: user?.isAuditor,
+  };
+
+  /** Client-side capability check. UI affordance only — the server re-checks
+   *  every gated route/action via can(). */
+  function can(cap: Capability, opts?: CapabilityOpts): boolean {
     if (!user?.activeRole) return false;
-    return hasMinimumRole(user.activeRole, minimumRole);
+    return allows(actor, cap, opts);
+  }
+  /** True if the actor has ANY of the capabilities (multi-access nav). */
+  function canAny(...caps: Capability[]): boolean {
+    if (!user?.activeRole) return false;
+    return allowsAny(actor, ...caps);
   }
 
   return {
     user,
     isLoading,
     isAuthenticated,
-    hasRole,
+    can,
+    canAny,
     activeBuildingId: user?.activeBuildingId ?? null,
     activeRole: user?.activeRole ?? null,
     buildings: user?.buildings ?? [],


### PR DESCRIPTION
Moves the **client-side** UI gating off `hasMinimumRole` onto the capability matrix (the matrix is pure, so `can()` runs client-side too). Per your call, the sidebar maps to **capabilities**, not role tiers.

- **`use-auth`**: drops `hasRole(minimumRole)`; exposes `can(cap, opts?)` + `canAny(...caps)`, built from the session actor (role + `isChair`/`ownsAnyUnit`/`isAuditor` from the JWT).
- **Sidebar nav config**: each item/section now declares `capabilities[]` instead of a `minimumRole` tier; visibility = `canAny(...)`. Nav reflects real access — e.g. Finance shows for `view.own.unit.finance` OR `view.building.finance` (owner sees own finance, a board member who owns no unit still sees building finance); admin section = `view.adminContext` OR `platform.admin`.
- **`RoleGuard`**: prop `role` → `capability`; the two admin pages pass `platform.admin`.
- **voting-page** `isBoardPlus` → `can("view.boardContext")`.

After this, **no `hasMinimumRole` call sites remain outside `rbac.ts`**.

## Verification
- 278 tests pass; tsc + lint clean.

## Remaining
- **C2b**: ~40 `requireRole` sites → `requireCapability` (the throwing sibling, still on the hierarchy).
- **D**: delete `hasMinimumRole`, `requireRole`, `ROLE_HIERARCHY`, legacy `canManage*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)