### PR TITLE
feat(authz): migrate requireRole → requireCapability (Phase C2b)

### DIFF
--- a/src/app/actions/finance.ts
+++ b/src/app/actions/finance.ts
@@ -2,7 +2,6 @@
 
 import { revalidatePath } from "next/cache";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
 import { requireCapability } from "@/lib/authz";
 import { requireNotFrozen } from "@/lib/frozen-check";
 import { requireFeature } from "@/lib/feature-gate";
@@ -99,8 +98,9 @@ const VALID_ACCOUNT_TYPES = ["ASSET", "LIABILITY", "INCOME", "EXPENSE"];
 
 export async function importAccounts(rows: ImportRow[]): Promise<ImportResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "view.adminContext");
     await requireFeature(buildingId, "finance");
 
     // Get existing accounts

--- a/src/app/actions/units.ts
+++ b/src/app/actions/units.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { requireNotFrozen } from "@/lib/frozen-check";
 import { checkUnitLimit } from "@/lib/plan-limits";
 import { createAuditLog } from "@/lib/audit";
@@ -25,8 +25,9 @@ interface UnitInput {
 
 export async function createUnit(input: UnitInput): Promise<ActionResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "units.manage");
     await requireNotFrozen(buildingId);
 
     const { allowed, current, max } = await checkUnitLimit(buildingId);
@@ -90,8 +91,9 @@ export async function createUnit(input: UnitInput): Promise<ActionResult> {
 
 export async function updateUnit(id: string, input: Partial<UnitInput>): Promise<ActionResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "units.manage");
     await requireNotFrozen(buildingId);
 
     const existing = await prisma.unit.findUnique({
@@ -190,8 +192,9 @@ export async function updateUnit(id: string, input: Partial<UnitInput>): Promise
 
 export async function deleteUnit(id: string): Promise<ActionResult> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "units.manage");
     await requireNotFrozen(buildingId);
 
     const unit = await prisma.unit.findUnique({
@@ -259,8 +262,9 @@ interface ImportResultType {
 
 export async function importUnits(rows: ImportRow[]): Promise<ImportResultType> {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
+    requireCapability(ctx, "units.manage");
     await requireNotFrozen(buildingId);
 
     const { allowed, current, max } = await checkUnitLimit(buildingId);

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -3,8 +3,7 @@
 import { revalidatePath } from "next/cache";
 import crypto from "crypto";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
-import { allows } from "@/lib/authz";
+import { allows, requireCapability } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import { BuildingRole, UnitRelationship } from "@prisma/client";
@@ -38,8 +37,9 @@ interface UpdateUserInput {
 
 export async function createUser(input: CreateUserInput): Promise<ActionResult> {
   try {
-    const { userId: currentUserId, buildingId, role: activeRole } = await requireBuildingContext();
-    await requireRole(activeRole, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId: currentUserId, buildingId, role: activeRole } = ctx;
+    requireCapability(ctx, "users.manage");
 
     const { email, name, role, unitId, temporaryPassword, isPrimaryContact, relationship, contactConsent } = input;
 
@@ -133,8 +133,9 @@ export async function createUser(input: CreateUserInput): Promise<ActionResult> 
 
 export async function updateUser(id: string, input: UpdateUserInput): Promise<ActionResult> {
   try {
-    const { userId: currentUserId, buildingId, role: activeRole } = await requireBuildingContext();
-    await requireRole(activeRole, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId: currentUserId, buildingId, role: activeRole } = ctx;
+    requireCapability(ctx, "users.manage");
 
     const userBuilding = await prisma.userBuilding.findFirst({
       where: { userId: id, buildingId },
@@ -241,8 +242,9 @@ export async function updateUser(id: string, input: UpdateUserInput): Promise<Ac
 
 export async function toggleUserActive(id: string): Promise<ActionResult> {
   try {
-    const { userId: currentUserId, buildingId, role: activeRole } = await requireBuildingContext();
-    await requireRole(activeRole, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId: currentUserId, buildingId } = ctx;
+    requireCapability(ctx, "users.manage");
 
     const userBuilding = await prisma.userBuilding.findFirst({
       where: { userId: id, buildingId },
@@ -295,8 +297,9 @@ const TRUTHY = new Set(["true", "yes", "1", "igen"]);
 
 export async function importUsers(rows: ImportRow[]): Promise<ImportResultType> {
   try {
-    const { userId: currentUserId, buildingId, role: activeRole } = await requireBuildingContext();
-    await requireRole(activeRole, "ADMIN");
+    const ctx = await requireBuildingContext();
+    const { userId: currentUserId, buildingId, role: activeRole } = ctx;
+    requireCapability(ctx, "users.manage");
 
     // Build unit number → id map
     const units = await prisma.unit.findMany({

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -1,14 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { getAuditLogs } from "@/lib/audit";
 
 export async function GET(request: NextRequest) {
   try {
-    const { buildingId, role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
-      await requireRole(activeRole, "ADMIN");
+      requireCapability(ctx, "audit.read");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/buildings/[id]/route.ts
+++ b/src/app/api/buildings/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(
@@ -52,10 +52,10 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
     try {
-      await requireRole(activeRole, "SUPER_ADMIN");
+      requireCapability(ctx, "building.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -115,10 +115,10 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
     try {
-      await requireRole(activeRole, "SUPER_ADMIN");
+      requireCapability(ctx, "building.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/buildings/route.ts
+++ b/src/app/api/buildings/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser, requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 
 export async function GET() {
@@ -67,10 +67,10 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
-    const { role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
 
     try {
-      await requireRole(activeRole, "SUPER_ADMIN");
+      requireCapability(ctx, "building.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
-import { allows } from "@/lib/authz";
+import { allows, requireCapability } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { documentUpdated, documentDeleted } from "@/lib/documents/events";
 
@@ -142,10 +141,11 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
 export async function DELETE(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "view.adminContext");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/documents/categories/route.ts
+++ b/src/app/api/documents/categories/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
-import { allows } from "@/lib/authz";
+import { allows, requireCapability } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { DocumentVisibility } from "@prisma/client";
 import { documentCategoryCreated } from "@/lib/documents/events";
@@ -84,10 +83,11 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "view.adminContext");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/finance/charges/[id]/route.ts
+++ b/src/app/api/finance/charges/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import {
   findChargeForBuildingScopedUpdate,
   markChargeAsPaid,
@@ -13,7 +13,8 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "finance");
@@ -28,7 +29,7 @@ export async function PATCH(
     }
 
     try {
-      await requireRole(role, "BOARD_MEMBER");
+      requireCapability(ctx, "board.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/finance/charges/route.ts
+++ b/src/app/api/finance/charges/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
-import { allows } from "@/lib/authz";
+import { allows, requireCapability } from "@/lib/authz";
 import {
   findUnitInBuilding,
   listBuildingUnitIds,
@@ -88,7 +87,8 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
       await requireFeature(buildingId, "finance");
@@ -103,7 +103,7 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      await requireRole(role, "BOARD_MEMBER");
+      requireCapability(ctx, "board.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/invitations/[id]/resend/route.ts
+++ b/src/app/api/invitations/[id]/resend/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { generateInvitationToken, getInvitationExpiryDate } from "@/lib/invitation";
 
@@ -14,10 +14,11 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "users.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/invitations/[id]/revoke/route.ts
+++ b/src/app/api/invitations/[id]/revoke/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 
 /**
@@ -12,10 +12,11 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "users.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { generateInvitationToken, getInvitationExpiryDate } from "@/lib/invitation";
 import { BuildingRole, InvitationStatus } from "@prisma/client";
@@ -11,10 +11,11 @@ import { BuildingRole, InvitationStatus } from "@prisma/client";
  */
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "users.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -148,10 +149,11 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "users.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/reports/generate/route.ts
+++ b/src/app/api/reports/generate/route.ts
@@ -11,7 +11,7 @@ import {
   computeMinutesHash,
   computeAuditSliceHash,
 } from "@/lib/reports/version-hash";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability, type BuildingActor } from "@/lib/authz";
 import {
   findVoteBuildingScope,
   findMeetingBuildingScope,
@@ -147,7 +147,7 @@ async function resolveTarget(opts: {
 async function applyKindGating(
   kind: ReportKind,
   buildingId: string,
-  role: string,
+  ctx: BuildingActor,
 ): Promise<NextResponse | null> {
   try {
     if (
@@ -162,9 +162,9 @@ async function applyKindGating(
       kind === "utility-statement"
     ) {
       await requireFeature(buildingId, "finance");
-      await requireRole(role, "BOARD_MEMBER");
+      requireCapability(ctx, "view.building.finance");
     } else if (kind === "audit-slice") {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "view.adminContext");
     }
     return null;
   } catch (err) {
@@ -192,7 +192,8 @@ async function applyKindGating(
  */
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     const body = parseBody(await request.json().catch(() => null));
     if (!body) {
@@ -200,7 +201,7 @@ export async function POST(request: NextRequest) {
     }
     const { kind, refId } = body;
 
-    const gate = await applyKindGating(kind, buildingId, role);
+    const gate = await applyKindGating(kind, buildingId, ctx);
     if (gate) return gate;
 
     const resolved = await resolveTarget({ kind, refId, buildingId });

--- a/src/app/api/units/[id]/route.ts
+++ b/src/app/api/units/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import { requireNotFrozen, FrozenBuildingError } from "@/lib/frozen-check";
@@ -12,10 +12,11 @@ type RouteContext = {
 
 export async function GET(request: NextRequest, context: RouteContext) {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "units.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -64,10 +65,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "units.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -188,10 +190,11 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
 export async function DELETE(request: NextRequest, context: RouteContext) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "units.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/units/route.ts
+++ b/src/app/api/units/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import { requireNotFrozen, FrozenBuildingError } from "@/lib/frozen-check";
@@ -9,10 +9,11 @@ import { Prisma } from "@prisma/client";
 
 export async function GET() {
   try {
-    const { buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "units.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -77,10 +78,11 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, buildingId, role } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
-      await requireRole(role, "ADMIN");
+      requireCapability(ctx, "units.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
-import { allows } from "@/lib/authz";
+import { allows, requireCapability } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import { BuildingRole, UnitRelationship } from "@prisma/client";
@@ -11,10 +10,11 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { userId: currentUserId, buildingId, role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId: currentUserId, buildingId, role: activeRole } = ctx;
 
     try {
-      await requireRole(activeRole, "ADMIN");
+      requireCapability(ctx, "users.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
-import { allows } from "@/lib/authz";
+import { allows, requireCapability } from "@/lib/authz";
 import { createAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
@@ -10,10 +9,11 @@ import { hashPassword } from "@/lib/password";
 
 export async function GET(request: NextRequest) {
   try {
-    const { userId, buildingId, role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId, buildingId } = ctx;
 
     try {
-      await requireRole(activeRole, "ADMIN");
+      requireCapability(ctx, "users.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
@@ -121,10 +121,11 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId: currentUserId, buildingId, role: activeRole } = await requireBuildingContext();
+    const ctx = await requireBuildingContext();
+    const { userId: currentUserId, buildingId, role: activeRole } = ctx;
 
     try {
-      await requireRole(activeRole, "ADMIN");
+      requireCapability(ctx, "users.manage");
     } catch {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/src/app/api/voting/votes/[id]/ballot/route.ts
+++ b/src/app/api/voting/votes/[id]/ballot/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
-import { requireRole } from "@/lib/rbac";
 import { allows } from "@/lib/authz";
 import { prisma } from "@/lib/prisma";
 import { createHash } from "crypto";

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -61,6 +61,8 @@ export type Capability =
   | "units.manage"
   | "contractor.view"
   | "contractor.manage"
+  | "building.manage"
+  | "audit.read"
   | "platform.subscriptions";
 
 /** Optional relational context for capabilities that compare the actor to a
@@ -82,6 +84,8 @@ const SUPER_ADMIN_CAPS: ReadonlySet<Capability> = new Set<Capability>([
   "units.manage",
   "contractor.view",
   "contractor.manage",
+  "building.manage",
+  "audit.read",
 ]);
 
 export interface ActorContext {
@@ -206,6 +210,14 @@ export function can(
 
     case "contractor.manage":
       return actor.role === "ADMIN";
+
+    case "audit.read":
+      // Audit-log access — admin (super via the early return above).
+      return actor.role === "ADMIN";
+
+    case "building.manage":
+      // Building CRUD — platform-level, SUPER_ADMIN only (handled above).
+      return false;
 
     case "platform.subscriptions":
       // Platform plan overrides — SUPER_ADMIN only (handled above).

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -9,8 +9,7 @@ import {
   requirePageFeature,
   requirePageCapability,
 } from "@/lib/page-guard";
-import { requireRole } from "@/lib/rbac";
-import { allows } from "@/lib/authz";
+import { allows, requireCapability } from "@/lib/authz";
 import { requireFeature } from "@/lib/feature-gate";
 import { prisma } from "@/lib/prisma";
 import { calculateMeetingQuorum } from "@/lib/voting/quorum";
@@ -34,8 +33,9 @@ export interface UnitsData {
 }
 
 export const getUnits = cache(async (): Promise<UnitsData> => {
-  const { buildingId, role } = await requireBuildingContext();
-  await requireRole(role, "ADMIN");
+  const ctx = await requireBuildingContext();
+  const { buildingId } = ctx;
+  requireCapability(ctx, "view.adminContext");
 
   const [units, building] = await Promise.all([
     prisma.unit.findMany({
@@ -103,8 +103,9 @@ export interface UsersData {
 }
 
 export const getUsers = cache(async (): Promise<UsersData> => {
-  const { buildingId, role } = await requireBuildingContext();
-  await requireRole(role, "ADMIN");
+  const ctx = await requireBuildingContext();
+  const { buildingId } = ctx;
+  requireCapability(ctx, "users.manage");
 
   const limit = 20;
   const where = { buildingId };
@@ -701,8 +702,9 @@ export interface AdminDashboardData {
 }
 
 export const getAdminDashboard = cache(async (): Promise<AdminDashboardData> => {
-  const { buildingId, role } = await requireBuildingContext();
-  await requireRole(role, "BOARD_MEMBER");
+  const ctx = await requireBuildingContext();
+  const { buildingId } = ctx;
+  requireCapability(ctx, "view.boardContext");
 
   const [totalResidents, totalUnits, openComplaintsCount, overduePaymentsCount, pendingMaintenanceCount] =
     await Promise.all([
@@ -1322,8 +1324,8 @@ export interface InvitationsData {
 
 export const getInvitations = cache(async (): Promise<InvitationsData> => {
   const ctx = await requireBuildingContext();
-  const { buildingId, role } = ctx;
-  await requireRole(role, "ADMIN");
+  const { buildingId } = ctx;
+  requireCapability(ctx, "users.manage");
 
   const invitations = await prisma.invitation.findMany({
     where: { buildingId },

--- a/src/lib/dashboard-dal.ts
+++ b/src/lib/dashboard-dal.ts
@@ -3,7 +3,7 @@ import { cache } from "react";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 
 // ─── Board dashboard data ──────────────────────────────────────────────────
 
@@ -126,8 +126,9 @@ function monthLabel(d: Date): string {
 // ─── Main loader ───────────────────────────────────────────────────────────
 
 export const getBoardDashboard = cache(async (): Promise<BoardDashboardData> => {
-  const { buildingId, role } = await requireBuildingContext();
-  await requireRole(role, "BOARD_MEMBER");
+  const ctx = await requireBuildingContext();
+  const { buildingId } = ctx;
+  requireCapability(ctx, "view.building.finance");
 
   // Compute month-window boundaries.
   const now = new Date();

--- a/src/lib/finance-dal.ts
+++ b/src/lib/finance-dal.ts
@@ -3,7 +3,7 @@ import { cache } from "react";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireBuildingContext } from "@/lib/auth";
-import { requireRole } from "@/lib/rbac";
+import { requireCapability } from "@/lib/authz";
 
 // ─── Shared types ─────────────────────────────────────────────────────────
 
@@ -247,8 +247,9 @@ function ledgerRow(e: {
 
 export const getFinanceOverviewBoard = cache(
   async (): Promise<FinanceOverviewBoardData> => {
-    const { buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
+    requireCapability(ctx, "view.building.finance");
 
     const now = new Date();
     const yearStart = new Date(now.getFullYear(), 0, 1);
@@ -359,8 +360,9 @@ export interface FinanceLedgerData {
 
 export const getFinanceLedger = cache(
   async (page = 1, pageSize = 30, accountId?: string): Promise<FinanceLedgerData> => {
-    const { buildingId, role } = await requireBuildingContext();
-    await requireRole(role, "BOARD_MEMBER");
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
+    requireCapability(ctx, "view.building.finance");
 
     const where = accountId
       ? {
@@ -420,8 +422,9 @@ export interface FinanceUnitsData {
 }
 
 export const getFinanceUnits = cache(async (): Promise<FinanceUnitsData> => {
-  const { buildingId, role } = await requireBuildingContext();
-  await requireRole(role, "BOARD_MEMBER");
+  const ctx = await requireBuildingContext();
+  const { buildingId } = ctx;
+  requireCapability(ctx, "view.building.finance");
 
   const year = new Date().getFullYear();
   const monthKeys = Array.from({ length: 12 }, (_, i) =>
@@ -517,8 +520,9 @@ export interface FinanceBudgetData {
 }
 
 export const getFinanceBudget = cache(async (): Promise<FinanceBudgetData> => {
-  const { buildingId, role } = await requireBuildingContext();
-  await requireRole(role, "BOARD_MEMBER");
+  const ctx = await requireBuildingContext();
+  const { buildingId } = ctx;
+  requireCapability(ctx, "view.building.finance");
 
   const year = new Date().getFullYear();
   const yearStart = new Date(year, 0, 1);

--- a/tests/lib/capabilities.test.ts
+++ b/tests/lib/capabilities.test.ts
@@ -192,6 +192,17 @@ describe("can() — board/admin read context", () => {
     expect(can(actor({ role: "ADMIN" }), "platform.admin")).toBe(false);
     expect(can(actor({ role: "BOARD_MEMBER", isChair: true }), "platform.admin")).toBe(false);
   });
+
+  it("audit.read: admin + super only", () => {
+    expect(can(actor({ role: "ADMIN" }), "audit.read")).toBe(true);
+    expect(can(actor({ role: "SUPER_ADMIN" }), "audit.read")).toBe(true);
+    expect(can(actor({ role: "BOARD_MEMBER", isChair: true }), "audit.read")).toBe(false);
+  });
+
+  it("building.manage: super-admin only", () => {
+    expect(can(actor({ role: "SUPER_ADMIN" }), "building.manage")).toBe(true);
+    expect(can(actor({ role: "ADMIN" }), "building.manage")).toBe(false);
+  });
 });
 
 describe("can() — governance: users.manage / contractor.manage", () => {


### PR DESCRIPTION
Migrates **all ~40 `requireRole(role, X)` call sites** (19 files) to `requireCapability(ctx, cap)`, threading the full `ActorContext`. After this, **nothing outside `rbac.ts` uses `requireRole` or `hasMinimumRole`** — clearing the way for Phase D deletion.

## New governance caps
- `building.manage` (SUPER_ADMIN) — buildings CRUD.
- `audit.read` (ADMIN + SUPER_ADMIN) — audit-log access.

## Mapping
- Buildings CRUD → `building.manage`
- Users / invitations → `users.manage`; audit logs → `audit.read`; units → `units.manage`
- Admin-only reads + doc management + admin finance import → `view.adminContext`
- Finance reads (finance-dal, dashboard board, reports finance floor) → `view.building.finance`
- Finance writes (charge create / mark-paid) → `board.manage`
- Admin-dashboard board read → `view.boardContext`
- Also removed a dead `requireRole` import in the voting ballot route.

## Verification
- **280 tests pass** (finance/reports/invitations/buildings/units route suites are the behavior net — no operational-vs-representative mismatches surfaced); tsc + lint clean. Matrix tests cover `building.manage` + `audit.read`.

## Next: Phase D
Delete `hasMinimumRole`, `requireRole`, `ROLE_HIERARCHY`, and the legacy `canManage*` wrappers from `rbac.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)