### PR TITLE
feat(voting): assembly Q&A — questions + raise-hand (Assembly Mode P3)

### DIFF
--- a/docs/data-model.dbml
+++ b/docs/data-model.dbml
@@ -420,6 +420,7 @@ the threat model warrants it.']
   meetingsCreated Meeting [not null]
   minutesEdited Meeting [not null]
   meetingRsvps MeetingRsvp [not null]
+  meetingQuestions MeetingQuestion [not null]
   votesCreated Vote [not null]
   ballots Ballot [not null]
   ballotsCastOnBehalf Ballot [not null]
@@ -1189,11 +1190,28 @@ the képviselő is running it, CLOSED after berekesztés.']
   rsvps MeetingRsvp [not null]
   attendances MeetingAttendance [not null]
   votes Vote [not null]
+  questions MeetingQuestion [not null, note: 'Live Q&A — questions + raise-hand requests from attendees.']
   pendingAgenda PendingAgendaItem [not null, note: 'Pending agenda items (resignations + escalated complaints) attached
 to this meeting. Source-of-truth for meeting agenda integration.']
   minutesSignatures MeetingMinutesSignature [not null, note: 'Chair + two-authenticator signatures on the jegyzőkönyv.']
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
+}
+
+Table MeetingQuestion {
+  id String [pk]
+  meeting Meeting [not null]
+  meetingId String [not null]
+  user User [not null]
+  userId String [not null]
+  type MeetingQuestionType [not null]
+  body String [note: 'Question text; null for a raise-hand request.']
+  agendaIndex Int [not null, default: 0, note: 'Agenda point index this was raised at.']
+  status MeetingQuestionStatus [not null, default: 'PENDING']
+  createdAt DateTime [default: `now()`, not null]
+
+  Note: 'Live Q&A item raised by an attendee during an assembly — either a typed
+question or a raise-hand request to speak. Logged into the minutes.'
 }
 
 Table MeetingRsvp {
@@ -1653,6 +1671,16 @@ Enum MeetingVoteMode {
   HANDS
 }
 
+Enum MeetingQuestionType {
+  QUESTION
+  HAND
+}
+
+Enum MeetingQuestionStatus {
+  PENDING
+  ADDRESSED
+}
+
 Enum ReportStatus {
   PENDING
   RUNNING
@@ -1885,6 +1913,10 @@ Ref: Meeting.minutesUpdatedById > User.id
 Ref: Meeting.createdById > User.id
 
 Ref: Meeting.buildingId > Building.id
+
+Ref: MeetingQuestion.meetingId > Meeting.id [delete: Cascade]
+
+Ref: MeetingQuestion.userId > User.id
 
 Ref: MeetingRsvp.meetingId > Meeting.id [delete: Cascade]
 

--- a/prisma/migrations/20260630082038_meeting_questions/migration.sql
+++ b/prisma/migrations/20260630082038_meeting_questions/migration.sql
@@ -1,0 +1,18 @@
+-- Live assembly Q&A: questions + raise-hand requests.
+CREATE TYPE "MeetingQuestionType" AS ENUM ('QUESTION', 'HAND');
+CREATE TYPE "MeetingQuestionStatus" AS ENUM ('PENDING', 'ADDRESSED');
+
+CREATE TABLE "MeetingQuestion" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" "MeetingQuestionType" NOT NULL,
+    "body" TEXT,
+    "agendaIndex" INTEGER NOT NULL DEFAULT 0,
+    "status" "MeetingQuestionStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "MeetingQuestion_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX "MeetingQuestion_meetingId_status_idx" ON "MeetingQuestion"("meetingId", "status");
+ALTER TABLE "MeetingQuestion" ADD CONSTRAINT "MeetingQuestion_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "MeetingQuestion" ADD CONSTRAINT "MeetingQuestion_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -695,6 +695,7 @@ model User {
   meetingsCreated         Meeting[]                   @relation("MeetingCreator")
   minutesEdited           Meeting[]                   @relation("MinutesEditor")
   meetingRsvps            MeetingRsvp[]
+  meetingQuestions        MeetingQuestion[]
   votesCreated            Vote[]                      @relation("VoteCreator")
   ballots                 Ballot[]                    @relation("BallotVoter")
   ballotsCastOnBehalf     Ballot[]                    @relation("BallotCaster")
@@ -1729,6 +1730,8 @@ model Meeting {
   rsvps              MeetingRsvp[]
   attendances        MeetingAttendance[]
   votes              Vote[]
+  /// Live Q&A — questions + raise-hand requests from attendees.
+  questions          MeetingQuestion[]
   /// Pending agenda items (resignations + escalated complaints) attached
   /// to this meeting. Source-of-truth for meeting agenda integration.
   pendingAgenda      PendingAgendaItem[]
@@ -1740,6 +1743,35 @@ model Meeting {
   @@index([date])
   @@index([createdById])
   @@index([buildingId])
+}
+
+enum MeetingQuestionType {
+  QUESTION
+  HAND
+}
+
+enum MeetingQuestionStatus {
+  PENDING
+  ADDRESSED
+}
+
+/// Live Q&A item raised by an attendee during an assembly — either a typed
+/// question or a raise-hand request to speak. Logged into the minutes.
+model MeetingQuestion {
+  id          String                @id @default(cuid())
+  meeting     Meeting               @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  meetingId   String
+  user        User                  @relation(fields: [userId], references: [id])
+  userId      String
+  type        MeetingQuestionType
+  /// Question text; null for a raise-hand request.
+  body        String?               @db.Text
+  /// Agenda point index this was raised at.
+  agendaIndex Int                   @default(0)
+  status      MeetingQuestionStatus @default(PENDING)
+  createdAt   DateTime              @default(now())
+
+  @@index([meetingId, status])
 }
 
 model MeetingRsvp {

--- a/src/app/api/voting/meetings/[id]/questions/[qid]/route.ts
+++ b/src/app/api/voting/meetings/[id]/questions/[qid]/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireBuildingContext } from "@/lib/auth";
+import { allows } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+import { publishToMeeting } from "@/lib/assembly-bus";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string; qid: string }> };
+
+/**
+ * Presenter moderates a Q&A item — mark it addressed (felolvasva / szót adva).
+ * Board-gated (vote.start).
+ */
+export async function PATCH(request: NextRequest, ctx: RouteContext) {
+  let actor;
+  try {
+    actor = await requireBuildingContext();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!allows(actor, "vote.start")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id, qid } = await ctx.params;
+  const q = await prisma.meetingQuestion.findUnique({
+    where: { id: qid },
+    select: { meetingId: true, meeting: { select: { buildingId: true } } },
+  });
+  if (!q || q.meetingId !== id || q.meeting.buildingId !== actor.buildingId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await prisma.meetingQuestion.update({
+    where: { id: qid },
+    data: { status: "ADDRESSED" },
+  });
+  publishToMeeting(id, { type: "session:question", meetingId: id });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/voting/meetings/[id]/questions/route.ts
+++ b/src/app/api/voting/meetings/[id]/questions/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireBuildingContext } from "@/lib/auth";
+import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
+import { prisma } from "@/lib/prisma";
+import { publishToMeeting } from "@/lib/assembly-bus";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * POST a live Q&A item during an assembly — a typed question or a raise-hand
+ * request. Any building member; only while the session is LIVE.
+ */
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  let actor;
+  try {
+    actor = await requireBuildingContext();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    await requireFeature(actor.buildingId, "voting");
+  } catch (err) {
+    if (err instanceof FeatureGateError) {
+      return NextResponse.json({ error: err.message, upgrade: true }, { status: 403 });
+    }
+    throw err;
+  }
+
+  const { id } = await ctx.params;
+  const meeting = await prisma.meeting.findUnique({
+    where: { id },
+    select: { buildingId: true, liveStatus: true, currentAgendaIndex: true },
+  });
+  if (!meeting || meeting.buildingId !== actor.buildingId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (meeting.liveStatus !== "LIVE") {
+    return NextResponse.json({ error: "Assembly is not live" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const type = body?.type === "HAND" ? "HAND" : "QUESTION";
+  const text = typeof body?.body === "string" ? body.body.trim().slice(0, 800) : "";
+  if (type === "QUESTION" && !text) {
+    return NextResponse.json({ error: "Question text required" }, { status: 400 });
+  }
+
+  await prisma.meetingQuestion.create({
+    data: {
+      meetingId: id,
+      userId: actor.userId,
+      type,
+      body: type === "QUESTION" ? text : null,
+      agendaIndex: meeting.currentAgendaIndex,
+    },
+  });
+  publishToMeeting(id, { type: "session:question", meetingId: id });
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/voting/assembly-companion.tsx
+++ b/src/components/voting/assembly-companion.tsx
@@ -46,6 +46,32 @@ export function AssemblyCompanion({
   const [detail, setDetail] = useState<VoteDetail | null>(null);
   const [picked, setPicked] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [composing, setComposing] = useState(false);
+  const [qText, setQText] = useState("");
+  const [sent, setSent] = useState<"q" | "h" | null>(null);
+  const [sending, setSending] = useState(false);
+
+  async function submitQuestion(type: "QUESTION" | "HAND", text?: string) {
+    if (sending) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/api/voting/meetings/${meeting.id}/questions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, body: text }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        toast.error(d.error || t("actionFailed"));
+        return;
+      }
+      setSent(type === "HAND" ? "h" : "q");
+      setComposing(false);
+      setQText("");
+    } finally {
+      setSending(false);
+    }
+  }
 
   useAssemblyStream(meeting.id, () => router.refresh());
 
@@ -213,19 +239,45 @@ export function AssemblyCompanion({
           </div>
         )}
 
-        {/* interaction (P3) */}
-        <div className="grid grid-cols-2 gap-2.5">
-          <button disabled className="rounded-2xl p-3.5 text-center opacity-60"
-            style={{ background: "var(--color-card)", border: "1px solid color-mix(in srgb, var(--color-ink) 11%, transparent)" }}>
-            <strong className="font-display text-[13px] block">{t("companionAsk")}</strong>
-            <small style={{ color: "var(--color-muted)" }}>{t("soon")}</small>
-          </button>
-          <button disabled className="rounded-2xl p-3.5 text-center opacity-60"
-            style={{ background: "var(--color-card)", border: "1px solid color-mix(in srgb, var(--color-ink) 11%, transparent)" }}>
-            <strong className="font-display text-[13px] block">{t("companionRaiseHand")}</strong>
-            <small style={{ color: "var(--color-muted)" }}>{t("soon")}</small>
-          </button>
-        </div>
+        {/* interaction (Q&A) */}
+        {sent ? (
+          <div className="rounded-2xl p-3.5 text-center text-[13px] font-semibold"
+            style={{ background: "color-mix(in srgb, var(--color-moss) 14%, var(--color-card))", color: "var(--color-moss)" }}>
+            ✓ {sent === "h" ? t("handSent") : t("questionSent")}
+          </div>
+        ) : composing ? (
+          <div className="rounded-2xl p-3" style={{ background: "var(--color-card)", border: "1px solid color-mix(in srgb, var(--color-ink) 11%, transparent)" }}>
+            <textarea value={qText} onChange={(e) => setQText(e.target.value)} rows={3}
+              placeholder={t("askPlaceholder")} autoFocus
+              className="w-full rounded-lg p-2.5 text-[14px] outline-none"
+              style={{ border: "1px solid color-mix(in srgb, var(--color-ink) 14%, transparent)", background: "var(--color-bg-3)", resize: "none" }} />
+            <div className="mt-2 flex gap-2">
+              <button onClick={() => { setComposing(false); setQText(""); }}
+                className="flex-1 rounded-lg py-2.5 text-sm font-semibold"
+                style={{ border: "1px solid color-mix(in srgb, var(--color-ink) 12%, transparent)", color: "var(--color-ink-soft)" }}>
+                {t("cancel")}
+              </button>
+              <button disabled={!qText.trim() || sending} onClick={() => submitQuestion("QUESTION", qText.trim())}
+                className="flex-1 rounded-lg py-2.5 text-sm font-bold disabled:opacity-50"
+                style={{ background: "var(--color-ink)", color: "var(--color-bg)" }}>
+                {t("send")}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-2.5">
+            <button onClick={() => setComposing(true)}
+              className="rounded-2xl p-3.5 text-center"
+              style={{ background: "var(--color-card)", border: "1px solid color-mix(in srgb, var(--color-ink) 11%, transparent)" }}>
+              <strong className="font-display text-[13px] block">{t("companionAsk")}</strong>
+            </button>
+            <button disabled={sending} onClick={() => submitQuestion("HAND")}
+              className="rounded-2xl p-3.5 text-center disabled:opacity-50"
+              style={{ background: "var(--color-card)", border: "1px solid color-mix(in srgb, var(--color-ink) 11%, transparent)" }}>
+              <strong className="font-display text-[13px] block">{t("companionRaiseHand")}</strong>
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/voting/assembly-presenter.tsx
+++ b/src/components/voting/assembly-presenter.tsx
@@ -87,6 +87,15 @@ export function AssemblyPresenter({
     }
   }
 
+  async function markQuestion(qid: string) {
+    await fetch(`/api/voting/meetings/${meeting.id}/questions/${qid}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "ADDRESSED" }),
+    });
+    router.refresh();
+  }
+
   // ── SETUP ──────────────────────────────────────────────────────────────
   if (meeting.liveStatus !== "LIVE") {
     const closed = meeting.liveStatus === "CLOSED";
@@ -247,8 +256,44 @@ export function AssemblyPresenter({
             </div>
           </div>
           <div className="px-5 py-4">
-            <span className="font-mono text-[10.5px] uppercase tracking-widest" style={{ color: "var(--color-muted)" }}>{t("questionsTitle")}</span>
-            <p className="mt-3 text-[12.5px] text-center" style={{ color: "var(--color-muted)" }}>{t("questionsSoon")}</p>
+            {(() => {
+              const pending = meeting.questions.filter((q) => q.status === "PENDING");
+              return (
+                <>
+                  <div className="flex items-center justify-between">
+                    <span className="font-mono text-[10.5px] uppercase tracking-widest" style={{ color: "var(--color-muted)" }}>{t("questionsTitle")}</span>
+                    <span className="font-mono text-[10.5px] rounded-full px-2 py-0.5" style={{ background: "color-mix(in srgb, var(--color-ink) 7%, transparent)", color: "var(--color-ink-soft)" }}>{pending.length}</span>
+                  </div>
+                  {pending.length === 0 ? (
+                    <p className="mt-3 text-[12.5px] text-center" style={{ color: "var(--color-muted)" }}>{t("questionsEmpty")}</p>
+                  ) : (
+                    <div className="mt-3 flex flex-col">
+                      {pending.map((q) => (
+                        <div key={q.id} className="flex gap-2.5 py-2.5" style={{ borderTop: "1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)" }}>
+                          <span className="grid place-items-center rounded-lg font-display text-[11px] font-semibold shrink-0"
+                            style={{ width: 28, height: 28, background: q.type === "HAND" ? "var(--color-moss)" : "var(--color-ochre)", color: q.type === "HAND" ? "#f5f2e6" : "var(--color-ink)" }}>
+                            {q.userName.split(" ").map((s) => s[0]).slice(0, 2).join("")}
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <div className="text-[13px] font-semibold">
+                              {q.userName} <span className="font-mono text-[10px] font-normal" style={{ color: "var(--color-muted)" }}>{q.agendaIndex + 1}. {t("pointShort")}</span>
+                            </div>
+                            <div className="text-[12.5px] mt-0.5" style={{ color: "var(--color-ink-soft)" }}>
+                              {q.type === "HAND" ? t("raisedHand") : q.body}
+                            </div>
+                          </div>
+                          <button onClick={() => markQuestion(q.id)}
+                            className="self-center font-mono text-[10px] uppercase tracking-wider rounded-md px-2 py-1 shrink-0"
+                            style={{ border: "1px solid color-mix(in srgb, var(--color-ink) 12%, transparent)", color: "var(--color-ink-soft)" }}>
+                            {q.type === "HAND" ? t("grantFloor") : t("markRead")}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              );
+            })()}
           </div>
         </aside>
       </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2097,7 +2097,17 @@
     "companionTallyHidden": "The result is hidden until close.",
     "companionAsk": "Question",
     "companionRaiseHand": "Raise hand",
-    "soon": "Soon"
+    "soon": "Soon",
+    "pointShort": "point",
+    "raisedHand": "Raised a hand to speak",
+    "grantFloor": "Grant",
+    "markRead": "Read out",
+    "questionsEmpty": "No questions.",
+    "askPlaceholder": "Type your question…",
+    "send": "Send",
+    "cancel": "Cancel",
+    "questionSent": "Question sent to the chair",
+    "handSent": "Hand raised"
   },
   "impersonation": {
     "viewAsUser": "View as user",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2097,7 +2097,17 @@
     "companionTallyHidden": "Az eredmény a lezárásig rejtett.",
     "companionAsk": "Kérdés",
     "companionRaiseHand": "Hozzászólok",
-    "soon": "Hamarosan"
+    "soon": "Hamarosan",
+    "pointShort": "pont",
+    "raisedHand": "Jelentkezett hozzászólásra",
+    "grantFloor": "Szót ad",
+    "markRead": "Felolvasva",
+    "questionsEmpty": "Nincs kérdés.",
+    "askPlaceholder": "Írd be a kérdésed…",
+    "send": "Küldés",
+    "cancel": "Mégse",
+    "questionSent": "Kérdés elküldve a képviselőnek",
+    "handSent": "Jelentkezés elküldve"
   },
   "impersonation": {
     "viewAsUser": "Megtekintés felhasználóként",

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -419,6 +419,18 @@ export interface MeetingDetailData {
   canSignMinutes: boolean;
   /** Pre-resolved current user id for "have I already signed?" check. */
   currentUserId: string;
+  /** Live Q&A items (questions + raise-hand), oldest first. */
+  questions: MeetingQuestionItem[];
+}
+
+export interface MeetingQuestionItem {
+  id: string;
+  type: "QUESTION" | "HAND";
+  body: string | null;
+  userName: string;
+  agendaIndex: number;
+  status: "PENDING" | "ADDRESSED";
+  createdAt: string;
 }
 
 export const getMeetingDetail = cache(async (id: string): Promise<MeetingDetailData> => {
@@ -433,6 +445,10 @@ export const getMeetingDetail = cache(async (id: string): Promise<MeetingDetailD
       minutesUpdatedBy: { select: { name: true } },
       rsvps: {
         include: { user: { select: { id: true, name: true } } },
+      },
+      questions: {
+        include: { user: { select: { name: true } } },
+        orderBy: { createdAt: "asc" as const },
       },
       votes: {
         include: {
@@ -599,6 +615,15 @@ export const getMeetingDetail = cache(async (id: string): Promise<MeetingDetailD
     })),
     canSignMinutes: canEditMinutes,
     currentUserId: userId,
+    questions: meeting.questions.map((q) => ({
+      id: q.id,
+      type: q.type,
+      body: q.body,
+      userName: q.user.name,
+      agendaIndex: q.agendaIndex,
+      status: q.status,
+      createdAt: q.createdAt.toISOString(),
+    })),
   };
 });
 

--- a/tests/integration/assembly-questions-route.test.ts
+++ b/tests/integration/assembly-questions-route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { BuildingRole, MeetingLiveStatus } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Live Q&A: any member may submit a question / raise a hand while the
+ * assembly is LIVE; the presenter (board) marks items addressed.
+ */
+const { ctxMock } = vi.hoisted(() => ({ ctxMock: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ requireBuildingContext: ctxMock, getCurrentUser: vi.fn(), auth: vi.fn() }));
+
+const { POST } = await import("@/app/api/voting/meetings/[id]/questions/route");
+const { PATCH } = await import("@/app/api/voting/meetings/[id]/questions/[qid]/route");
+
+beforeEach(() => ctxMock.mockReset());
+
+function asActor(buildingId: string, userId: string, role: BuildingRole, isChair = false) {
+  ctxMock.mockResolvedValue({ userId, buildingId, role, isChair, isProfessional: false, ownsAnyUnit: false, isAuditor: false });
+}
+
+async function makeMeeting(buildingId: string, createdById: string, liveStatus: MeetingLiveStatus = "LIVE") {
+  return prisma.meeting.create({
+    data: { title: "Q2", date: new Date(), time: "18:00", buildingId, createdById, liveStatus, currentAgendaIndex: 1 },
+  });
+}
+
+function postReq(id: string, body: unknown) {
+  return [
+    new NextRequest(`http://test/api/voting/meetings/${id}/questions`, { method: "POST", body: JSON.stringify(body) }),
+    { params: Promise.resolve({ id }) },
+  ] as const;
+}
+
+describe("assembly Q&A", () => {
+  it("an owner raises a hand and asks a question while LIVE", async () => {
+    const { building } = await makeBuilding();
+    const u = await makeUser({ buildingId: building.id, role: "OWNER" });
+    const m = await makeMeeting(building.id, u.id);
+    asActor(building.id, u.id, "OWNER");
+
+    expect((await POST(...postReq(m.id, { type: "HAND" }))).status).toBe(200);
+    expect((await POST(...postReq(m.id, { type: "QUESTION", body: "Mikor kezdődik?" }))).status).toBe(200);
+    expect((await POST(...postReq(m.id, { type: "QUESTION" }))).status).toBe(400); // no body
+
+    const qs = await prisma.meetingQuestion.findMany({ where: { meetingId: m.id }, orderBy: { createdAt: "asc" } });
+    expect(qs.map((q) => q.type)).toEqual(["HAND", "QUESTION"]);
+    expect(qs[0].agendaIndex).toBe(1);
+    expect(qs[1].body).toBe("Mikor kezdődik?");
+  });
+
+  it("rejects submissions when the assembly is not LIVE", async () => {
+    const { building } = await makeBuilding();
+    const u = await makeUser({ buildingId: building.id, role: "OWNER" });
+    const m = await makeMeeting(building.id, u.id, "SCHEDULED");
+    asActor(building.id, u.id, "OWNER");
+    expect((await POST(...postReq(m.id, { type: "HAND" }))).status).toBe(400);
+  });
+
+  it("only the board may mark an item addressed", async () => {
+    const { building } = await makeBuilding();
+    const owner = await makeUser({ buildingId: building.id, role: "OWNER" });
+    const m = await makeMeeting(building.id, owner.id);
+    const q = await prisma.meetingQuestion.create({
+      data: { meetingId: m.id, userId: owner.id, type: "HAND", agendaIndex: 0 },
+    });
+    const patchReq = () =>
+      [
+        new NextRequest(`http://test/x`, { method: "PATCH", body: "{}" }),
+        { params: Promise.resolve({ id: m.id, qid: q.id }) },
+      ] as const;
+
+    asActor(building.id, owner.id, "OWNER");
+    expect((await PATCH(...patchReq())).status).toBe(403);
+
+    asActor(building.id, owner.id, "BOARD_MEMBER", true);
+    expect((await PATCH(...patchReq())).status).toBe(200);
+    expect((await prisma.meetingQuestion.findUnique({ where: { id: q.id } }))?.status).toBe("ADDRESSED");
+  });
+});


### PR DESCRIPTION
**Phase 3 of Közgyűlés Mód** — live Q&A. Attendees ask questions / raise a hand from the companion; the presenter sees a live queue and marks items addressed. Builds on #82/#83.

## What's in P3
- **`MeetingQuestion`** model (type QUESTION/HAND, body, agendaIndex, status PENDING/ADDRESSED) → Meeting + User. Migration applied non-destructively to dev + test.
- **Endpoints**: `POST …/meetings/[id]/questions` (any member, only while LIVE; QUESTION needs text and stamps the current agenda point) and `PATCH …/questions/[qid]` (board-gated → ADDRESSED). Both publish `session:question` on the SSE bus.
- **`getMeetingDetail`** returns the questions list (with asker name).
- **Companion**: the Question / Raise-hand buttons are now functional — inline question composer + one-tap hand, with a sent confirmation.
- **Presenter** side panel: placeholder replaced by the **live queue** (PENDING items: asker, agenda point, text or "raised a hand") + a per-item mark-addressed action; SSE-driven.
- i18n (hu+en).

## Verification
- **273 tests pass** (new: Q&A route — submit while LIVE, body required, not-live rejected, board-only moderation); tsc + lint clean.
- The full live loop is now exercisable on `:3100` (after the `NEXTAUTH_URL` fix): companion submits → `session:question` → presenter queue updates; presenter marks addressed.

## Next
**P4** — auto-minutes draft on adjournment (resolutions from closed votes + this question log → `Meeting.minutes`, then the existing PDF/signature flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)