### PR TITLE
feat(voting): auto-minutes draft on adjournment (Assembly Mode P4)

### DIFF
--- a/src/app/api/voting/meetings/[id]/live/route.ts
+++ b/src/app/api/voting/meetings/[id]/live/route.ts
@@ -5,6 +5,9 @@ import { allows } from "@/lib/authz";
 import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
 import { prisma } from "@/lib/prisma";
 import { publishToMeeting } from "@/lib/assembly-bus";
+import { getMeetingDetail } from "@/lib/dal";
+import { buildMinutesDraft } from "@/lib/voting/minutes-draft";
+import { meetingMinutesUpdated } from "@/lib/voting/events";
 
 export const runtime = "nodejs";
 
@@ -105,6 +108,31 @@ export async function POST(request: NextRequest, ctx: RouteContext) {
         where: { id },
         data: { liveStatus: "CLOSED", endedAt: new Date(), currentVoteId: null },
       });
+
+      // Auto-generate a jegyzőkönyv draft from the session record (closed-vote
+      // resolutions + Q&A log + quorum). Best-effort: never let a draft failure
+      // block the adjournment, and never clobber minutes already written.
+      try {
+        const detail = await getMeetingDetail(id);
+        if (!detail.minutes?.trim()) {
+          await prisma.meeting.update({
+            where: { id },
+            data: {
+              minutes: buildMinutesDraft(detail),
+              minutesUpdatedById: actor.userId,
+              minutesUpdatedAt: new Date(),
+            },
+          });
+          await meetingMinutesUpdated({
+            meetingId: id,
+            updatedByUserId: actor.userId,
+            buildingId: actor.buildingId,
+          });
+        }
+      } catch (err) {
+        console.error("Auto-minutes draft failed for meeting", id, err);
+      }
+
       publishToMeeting(id, { type: "session:ended", meetingId: id });
       return NextResponse.json({ ok: true });
     }

--- a/src/components/voting/assembly-presenter.tsx
+++ b/src/components/voting/assembly-presenter.tsx
@@ -104,8 +104,9 @@ export function AssemblyPresenter({
         <div className="mx-auto max-w-2xl px-6 py-16 text-center">
           <h1 className="font-display text-3xl text-ink">{t("closedHeading")}</h1>
           <p className="mt-3 text-ink-soft">{t("closedBody")}</p>
+          <p className="mt-1 text-sm text-muted">{t("closedDraftNote")}</p>
           <a
-            href={`/${locale}/voting/meetings/${meeting.id}`}
+            href={`/${locale}/voting/meetings/${meeting.id}?tab=minutes`}
             className="mt-6 inline-block rounded-xl bg-ink px-5 py-3 font-semibold text-bg"
           >
             {t("toMinutes")}

--- a/src/components/voting/meeting-detail.tsx
+++ b/src/components/voting/meeting-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import Link from "next/link";
 import {
@@ -41,7 +41,10 @@ const PILL_BASE =
 export function MeetingDetail({ meeting }: MeetingDetailProps) {
   const t = useTranslations("voting");
   const router = useRouter();
-  const [activeTab, setActiveTab] = useState<"overview" | "minutes">("overview");
+  const searchParams = useSearchParams();
+  const [activeTab, setActiveTab] = useState<"overview" | "minutes">(
+    searchParams.get("tab") === "minutes" ? "minutes" : "overview",
+  );
   const [editingAgenda, setEditingAgenda] = useState(false);
   const [agendaDraft, setAgendaDraft] = useState<AgendaItem[]>([]);
   const [agendaSaving, setAgendaSaving] = useState(false);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2047,6 +2047,7 @@
     "actionFailed": "The action failed.",
     "closedHeading": "Assembly adjourned",
     "closedBody": "The minutes draft is available on the meeting page.",
+    "closedDraftNote": "The system prepared a minutes draft from the votes and discussion — review it and have it authenticated.",
     "toMinutes": "Open minutes",
     "setupEyebrow": "Assembly mode · start",
     "setupHeading": "Start the assembly",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2047,6 +2047,7 @@
     "actionFailed": "A művelet nem sikerült.",
     "closedHeading": "Közgyűlés berekesztve",
     "closedBody": "A jegyzőkönyv-vázlat elérhető a közgyűlés oldalán.",
+    "closedDraftNote": "A rendszer a szavazások és a hozzászólások alapján elkészítette a jegyzőkönyv-tervezetet — ellenőrizze és hitelesíttesse.",
     "toMinutes": "Jegyzőkönyv megnyitása",
     "setupEyebrow": "Közgyűlés mód · indítás",
     "setupHeading": "Közgyűlés indítása",

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -405,6 +405,7 @@ export interface MeetingDetailData {
   currentAgendaIndex: number;
   currentVoteId: string | null;
   startedAt: string | null;
+  endedAt: string | null;
   minutes: string | null;
   minutesUpdatedAt: string | null;
   minutesUpdatedBy: { name: string } | null;
@@ -595,6 +596,7 @@ export const getMeetingDetail = cache(async (id: string): Promise<MeetingDetailD
     currentAgendaIndex: meeting.currentAgendaIndex,
     currentVoteId: meeting.currentVoteId,
     startedAt: meeting.startedAt?.toISOString() ?? null,
+    endedAt: meeting.endedAt?.toISOString() ?? null,
     minutes: meeting.minutes,
     minutesUpdatedAt: meeting.minutesUpdatedAt?.toISOString() ?? null,
     minutesUpdatedBy: meeting.minutesUpdatedBy ? { name: meeting.minutesUpdatedBy.name } : null,

--- a/src/lib/voting/minutes-draft.ts
+++ b/src/lib/voting/minutes-draft.ts
@@ -1,0 +1,165 @@
+import type { MeetingDetailData, MeetingVoteResult } from "@/lib/dal";
+
+/**
+ * Auto-generates a jegyzőkönyv (minutes) draft from a finished live assembly.
+ * Pulls the real session record — quorum, closed-vote resolutions with
+ * tallies, and the Q&A log — into a Markdown skeleton the képviselő then
+ * edits and has authenticated (the existing signature flow).
+ *
+ * The body is a Hungarian legal document by nature (Tht. §43), so its section
+ * labels are fixed Hungarian — same convention as the manual `buildTemplate`
+ * in minutes-editor.tsx. Only UI chrome goes through next-intl.
+ */
+
+const FORMAT_LABEL: Record<string, string> = {
+  IN_PERSON: "Személyes",
+  HYBRID: "Hibrid",
+  ONLINE: "Online",
+};
+
+const MAJORITY_LABEL: Record<string, string> = {
+  SIMPLE_MAJORITY: "egyszerű többség",
+  TWO_THIRDS: "minősített többség (2/3)",
+  FOUR_FIFTHS: "minősített többség (4/5)",
+  UNANIMOUS: "egyhangú",
+  PLURALITY: "relatív többség",
+};
+
+function fmtDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("hu-HU", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function pct(part: number, whole: number): string {
+  if (whole <= 0) return "0,0%";
+  return `${((part / whole) * 100).toLocaleString("hu-HU", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`;
+}
+
+function agendaTitles(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((it, i) => {
+    if (typeof it === "string") return it;
+    const o = (it ?? {}) as Record<string, unknown>;
+    return typeof o.title === "string" ? o.title : `${i + 1}. napirendi pont`;
+  });
+}
+
+function renderResolution(v: MeetingVoteResult, index: number): string[] {
+  const lines: string[] = [];
+  lines.push(`### ${index}. határozati javaslat — ${v.title}`);
+  lines.push("");
+
+  if (v.status !== "CLOSED") {
+    lines.push(`*A szavazás nem zárult le (állapot: ${v.status}).*`);
+    lines.push("");
+    return lines;
+  }
+
+  lines.push(`Szavazás módja: ${MAJORITY_LABEL[v.majorityType] ?? v.majorityType}. Leadott szavazatok: ${v.ballotCount}.`);
+  lines.push("");
+  lines.push("| Választás | Szavazat | Tulajdoni hányad |");
+  lines.push("| --- | ---: | ---: |");
+  for (const o of v.options) {
+    lines.push(`| ${o.label} | ${o.votes} | ${pct(o.weight, v.totalWeight)} |`);
+  }
+  lines.push("");
+
+  if (v.isAwardVote && v.award) {
+    if (v.award.outcome === "AWARDED") {
+      const amount =
+        v.award.winnerAmount != null
+          ? ` (${v.award.winnerAmount.toLocaleString("hu-HU")} Ft)`
+          : "";
+      lines.push(`**Eredmény: a közgyűlés a megbízást a(z) „${v.award.winnerLabel}" ajánlatnak ítélte oda${amount}.**`);
+    } else if (v.award.outcome === "NO_QUORUM") {
+      lines.push("**Eredmény: a szavazás határozatképtelen volt (a részvétel nem érte el az 50%-ot).**");
+    } else {
+      lines.push("**Eredmény: a közgyűlés egyik ajánlatot sem fogadta el.**");
+    }
+  } else if (v.passed === true) {
+    lines.push("**Eredmény: a közgyűlés a javaslatot ELFOGADTA.**");
+  } else if (v.passed === false) {
+    lines.push("**Eredmény: a közgyűlés a javaslatot ELUTASÍTOTTA.**");
+  } else {
+    lines.push("*Eredmény: nem megállapítható.*");
+  }
+  lines.push("");
+  return lines;
+}
+
+export function buildMinutesDraft(m: MeetingDetailData): string {
+  const lines: string[] = [];
+
+  lines.push(`# Jegyzőkönyv — ${m.title}`);
+  lines.push("");
+  lines.push(`**Időpont:** ${fmtDateTime(m.date)} ${m.time}`);
+  if (m.location) lines.push(`**Helyszín:** ${m.location}`);
+  if (m.format) lines.push(`**A közgyűlés formája:** ${FORMAT_LABEL[m.format] ?? m.format}`);
+  lines.push(`**Megnyitás:** ${fmtDateTime(m.startedAt)} · **Berekesztés:** ${fmtDateTime(m.endedAt)}`);
+  lines.push("");
+  lines.push("> Ezt a jegyzőkönyv-tervezetet a rendszer a közgyűlés mód alapján automatikusan készítette. Kérjük, ellenőrizze és egészítse ki, mielőtt hitelesítteti.");
+  lines.push("");
+
+  // ── Határozatképesség ────────────────────────────────────────────────
+  lines.push("## Határozatképesség");
+  lines.push("");
+  lines.push(
+    `Jelen lévő tulajdonostársak: ${m.quorum.presentUnitCount} / ${m.quorum.totalUnitCount} albetét, ` +
+      `a tulajdoni hányadok ${m.quorum.presentPercentage.toLocaleString("hu-HU", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%-a. ` +
+      `A közgyűlés ${m.quorum.isQuorate ? "**határozatképes**" : "**határozatképtelen**"}.`,
+  );
+  lines.push("");
+
+  // ── Napirend ─────────────────────────────────────────────────────────
+  const agenda = agendaTitles(m.agenda);
+  if (agenda.length > 0) {
+    lines.push("## Napirend");
+    lines.push("");
+    agenda.forEach((title, i) => lines.push(`${i + 1}. ${title}`));
+    lines.push("");
+  }
+
+  // ── Határozatok ──────────────────────────────────────────────────────
+  lines.push("## Határozatok");
+  lines.push("");
+  if (m.votes.length === 0) {
+    lines.push("*A közgyűlésen nem született szavazással hozott határozat.*");
+    lines.push("");
+  } else {
+    m.votes.forEach((v, i) => lines.push(...renderResolution(v, i + 1)));
+  }
+
+  // ── Kérdések és hozzászólások ────────────────────────────────────────
+  const questions = m.questions.filter((q) => q.type === "QUESTION" && q.body);
+  const hands = m.questions.filter((q) => q.type === "HAND");
+  if (questions.length > 0 || hands.length > 0) {
+    lines.push("## Kérdések és hozzászólások");
+    lines.push("");
+    for (const q of questions) {
+      lines.push(`- **${q.userName}** (${q.agendaIndex + 1}. napirendi pont): ${q.body}`);
+    }
+    if (hands.length > 0) {
+      const names = hands.map((h) => h.userName).join(", ");
+      lines.push(`- Szót kért: ${names}`);
+    }
+    lines.push("");
+  }
+
+  // ── Hitelesítés ──────────────────────────────────────────────────────
+  lines.push("---");
+  lines.push("");
+  lines.push("*A jegyzőkönyvet hitelesítette:*");
+  lines.push("");
+  lines.push("- Levezető elnök: ____________________");
+  lines.push("- Jegyzőkönyv-hitelesítő 1.: ____________________");
+  lines.push("- Jegyzőkönyv-hitelesítő 2.: ____________________");
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/tests/integration/assembly-minutes-draft.test.ts
+++ b/tests/integration/assembly-minutes-draft.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { BuildingRole } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Adjourning a live assembly (the `end` action) auto-generates a jegyzőkönyv
+ * draft from the session record: closed-vote resolutions + the Q&A log. The
+ * draft never clobbers minutes that were already written.
+ */
+const { ctxMock } = vi.hoisted(() => ({ ctxMock: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ requireBuildingContext: ctxMock, getCurrentUser: vi.fn(), auth: vi.fn() }));
+
+const { POST } = await import("@/app/api/voting/meetings/[id]/live/route");
+
+beforeEach(() => ctxMock.mockReset());
+
+function asActor(buildingId: string, userId: string, role: BuildingRole, isChair = false) {
+  ctxMock.mockResolvedValue({ userId, buildingId, role, isChair, isProfessional: false, ownsAnyUnit: false, isAuditor: false });
+}
+
+function endReq(id: string) {
+  return [
+    new NextRequest(`http://test/api/voting/meetings/${id}/live`, { method: "POST", body: JSON.stringify({ action: "end" }) }),
+    { params: Promise.resolve({ id }) },
+  ] as const;
+}
+
+/** A LIVE meeting with one CLOSED, passing YES/NO vote and one question. */
+async function makeSession(buildingId: string, createdById: string) {
+  const unit = await prisma.unit.create({
+    data: { number: "1", floor: 1, ownershipShare: "0.5000", size: "60.00", buildingId },
+  });
+  const meeting = await prisma.meeting.create({
+    data: {
+      title: "Q2 Közgyűlés", date: new Date(), time: "18:00", buildingId, createdById,
+      agenda: ["Megnyitó", "Tetőfelújítás elfogadása"], liveStatus: "LIVE", format: "HYBRID",
+    },
+  });
+  const vote = await prisma.vote.create({
+    data: {
+      title: "Tetőfelújítás elfogadása", voteType: "YES_NO", status: "CLOSED",
+      majorityType: "SIMPLE_MAJORITY", quorumRequired: "0.5000", deadline: new Date(),
+      buildingId, meetingId: meeting.id, createdById,
+      options: { create: [{ label: "Igen", sortOrder: 0 }, { label: "Nem", sortOrder: 1 }] },
+    },
+    include: { options: { orderBy: { sortOrder: "asc" } } },
+  });
+  await prisma.ballot.create({
+    data: { voteId: vote.id, optionId: vote.options[0].id, unitId: unit.id, userId: createdById, weight: "0.5000" },
+  });
+  await prisma.meetingQuestion.create({
+    data: { meetingId: meeting.id, userId: createdById, type: "QUESTION", body: "Mennyi a tartalék?", agendaIndex: 1, status: "ADDRESSED" },
+  });
+  return meeting;
+}
+
+describe("auto-minutes on adjournment", () => {
+  it("writes a draft from the closed-vote result and the Q&A log", async () => {
+    const { building } = await makeBuilding();
+    const u = await makeUser({ buildingId: building.id, role: "BOARD_MEMBER" });
+    const m = await makeSession(building.id, u.id);
+    asActor(building.id, u.id, "BOARD_MEMBER", true);
+
+    const res = await POST(...endReq(m.id));
+    expect(res.status).toBe(200);
+
+    const after = await prisma.meeting.findUnique({ where: { id: m.id } });
+    expect(after?.liveStatus).toBe("CLOSED");
+    expect(after?.minutesUpdatedById).toBe(u.id);
+    const md = after?.minutes ?? "";
+    expect(md).toContain("# Jegyzőkönyv");
+    expect(md).toContain("Tetőfelújítás elfogadása");
+    expect(md).toContain("ELFOGADTA"); // passing vote
+    expect(md).toContain("Mennyi a tartalék?"); // question log
+  });
+
+  it("does not overwrite minutes that already exist", async () => {
+    const { building } = await makeBuilding();
+    const u = await makeUser({ buildingId: building.id, role: "ADMIN" });
+    const m = await makeSession(building.id, u.id);
+    await prisma.meeting.update({ where: { id: m.id }, data: { minutes: "Kézzel írt jegyzőkönyv." } });
+    asActor(building.id, u.id, "ADMIN");
+
+    expect((await POST(...endReq(m.id))).status).toBe(200);
+    expect((await prisma.meeting.findUnique({ where: { id: m.id } }))?.minutes).toBe("Kézzel írt jegyzőkönyv.");
+  });
+});


### PR DESCRIPTION
**Phase 4 — the finale of Közgyűlés Mód.** When the képviselő adjourns a live assembly, the system auto-drafts the *jegyzőkönyv* from the session record, so they edit a populated draft instead of a blank template, then hand off to the existing PDF / signature flow.

## What's in P4
- **`buildMinutesDraft`** (`src/lib/voting/minutes-draft.ts`) — a pure generator turning a finished session into a Markdown jegyzőkönyv:
  - header (date, format, megnyitás/berekesztés times)
  - **Határozatképesség** (quorum: units present + ownership-share %)
  - **Napirend**
  - **Határozatok** — one block per vote: majority type, per-option tally with ownership-share %, and the result (**ELFOGADTA** / **ELUTASÍTOTTA**, or the award outcome for contractor votes)
  - **Kérdések és hozzászólások** — the P3 Q&A log
  - signature footer
  - Hungarian body by convention (it's a legal document — same precedent as the existing manual `buildTemplate`).
- **`end` action** generates the draft from `getMeetingDetail` (reusing the already-computed vote results + quorum), writes it to `Meeting.minutes` with `minutesUpdatedBy`, and fires `meetingMinutesUpdated`. **Best-effort**: a draft failure never blocks adjournment, and existing minutes are never clobbered.
- **Presenter** "berekesztve" screen notes the draft and links straight to the minutes tab (`?tab=minutes`); **meeting-detail** honors that query param.
- `getMeetingDetail` now exposes `endedAt` — **no schema change** (the column already existed from P1).
- i18n (hu+en).

## Verification
- **New integration test** drives the real path against Postgres — `end` → `getMeetingDetail` → `buildMinutesDraft` → DB write — asserting the closed-vote result and the question body land in the draft, plus idempotency (won't overwrite manual minutes).
- **275 tests pass**; tsc + P4-file lint clean.
- Running app: P4 changes hot-reloaded with zero compile/Prisma errors; `/live` and `?tab=minutes` routes serve cleanly.
- ⚠️ The browser-driven visual walkthrough is deferred — the Playwright MCP backend was unresponsive this session (app itself healthy over curl). The route is fully covered by the real-DB integration test.

## Közgyűlés Mód — complete
P1 session/presenter + SSE · P2 companion phone · P3 live Q&A · **P4 auto-minutes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)