### PR TITLE
feat(voting): link votes to agenda points + minutes date fix

### DIFF
--- a/src/components/voting/agenda-editor.tsx
+++ b/src/components/voting/agenda-editor.tsx
@@ -7,14 +7,18 @@ import { Plus, GripVertical, Trash2 } from "lucide-react";
 export interface AgendaItem {
   title: string;
   description: string;
+  /** Optional vote attached to this point — surfaced in Közgyűlés mód. */
+  voteId?: string;
 }
 
 interface AgendaEditorProps {
   items: AgendaItem[];
   onChange: (items: AgendaItem[]) => void;
+  /** Votes belonging to this meeting, offered as per-point attachments. */
+  votes?: { id: string; title: string }[];
 }
 
-export function AgendaEditor({ items, onChange }: AgendaEditorProps) {
+export function AgendaEditor({ items, onChange, votes = [] }: AgendaEditorProps) {
   const t = useTranslations("voting");
   const [dragIndex, setDragIndex] = useState<number | null>(null);
 
@@ -26,9 +30,16 @@ export function AgendaEditor({ items, onChange }: AgendaEditorProps) {
     onChange(items.filter((_, i) => i !== index));
   }
 
-  function updateItem(index: number, field: keyof AgendaItem, value: string) {
+  function updateItem(index: number, field: "title" | "description", value: string) {
     const updated = items.map((item, i) =>
       i === index ? { ...item, [field]: value } : item
+    );
+    onChange(updated);
+  }
+
+  function setVote(index: number, voteId: string) {
+    const updated = items.map((item, i) =>
+      i === index ? { ...item, voteId: voteId || undefined } : item
     );
     onChange(updated);
   }
@@ -111,6 +122,20 @@ export function AgendaEditor({ items, onChange }: AgendaEditorProps) {
                 placeholder={t("agendaItemDescription")}
                 className="w-full rounded-md border border-ink/8 bg-card px-3 py-1.5 text-xs text-ink-soft placeholder:text-muted focus:border-ink/40 focus:outline-none"
               />
+              {votes.length > 0 && (
+                <select
+                  value={item.voteId ?? ""}
+                  onChange={(e) => setVote(index, e.target.value)}
+                  className="w-full rounded-md border border-ink/8 bg-card px-3 py-1.5 text-xs text-ink-soft focus:border-ink/40 focus:outline-none"
+                >
+                  <option value="">{t("agendaNoVote")}</option>
+                  {votes.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      {t("agendaLinkedVote")}: {v.title}
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
 
             <button

--- a/src/components/voting/meeting-detail.tsx
+++ b/src/components/voting/meeting-detail.tsx
@@ -269,16 +269,21 @@ export function MeetingDetail({ meeting }: MeetingDetailProps) {
                   <button
                     onClick={() => {
                       setAgendaDraft(
-                        agendaItems.map((item: unknown) => ({
-                          title:
-                            typeof item === "string"
-                              ? item
-                              : String((item as Record<string, unknown>)?.title ?? ""),
-                          description:
+                        agendaItems.map((item: unknown) => {
+                          const obj =
                             typeof item === "object" && item !== null
-                              ? String((item as Record<string, unknown>)?.description ?? "")
-                              : "",
-                        }))
+                              ? (item as Record<string, unknown>)
+                              : null;
+                          return {
+                            title:
+                              typeof item === "string"
+                                ? item
+                                : String(obj?.title ?? ""),
+                            description: obj ? String(obj.description ?? "") : "",
+                            voteId:
+                              obj && typeof obj.voteId === "string" ? obj.voteId : undefined,
+                          };
+                        })
                       );
                       setEditingAgenda(true);
                     }}
@@ -292,7 +297,11 @@ export function MeetingDetail({ meeting }: MeetingDetailProps) {
 
               {editingAgenda ? (
                 <div className="space-y-4">
-                  <AgendaEditor items={agendaDraft} onChange={setAgendaDraft} />
+                  <AgendaEditor
+                    items={agendaDraft}
+                    onChange={setAgendaDraft}
+                    votes={meeting.votes.map((v) => ({ id: v.id, title: v.title }))}
+                  />
                   <div className="flex items-center justify-end gap-2 pt-3 border-t border-ink/10">
                     <button
                       onClick={() => setEditingAgenda(false)}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1880,6 +1880,8 @@
     "addAgendaItem": "Add item",
     "agendaItemTitle": "Agenda item title",
     "agendaItemDescription": "Description (optional)",
+    "agendaNoVote": "No linked vote",
+    "agendaLinkedVote": "Vote",
     "agendaSaved": "Agenda saved",
     "agendaSaveFailed": "Failed to save agenda",
     "attendeesTitle": "Responses",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -1880,6 +1880,8 @@
     "addAgendaItem": "Pont hozzáadása",
     "agendaItemTitle": "Napirendi pont címe",
     "agendaItemDescription": "Leírás (opcionális)",
+    "agendaNoVote": "Nincs kapcsolódó szavazás",
+    "agendaLinkedVote": "Szavazás",
     "agendaSaved": "Napirend mentve",
     "agendaSaveFailed": "Nem sikerült menteni a napirendet",
     "attendeesTitle": "Visszajelzések",

--- a/src/lib/voting/minutes-draft.ts
+++ b/src/lib/voting/minutes-draft.ts
@@ -36,6 +36,15 @@ function fmtDateTime(iso: string | null): string {
   });
 }
 
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("hu-HU", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
 function pct(part: number, whole: number): string {
   if (whole <= 0) return "0,0%";
   return `${((part / whole) * 100).toLocaleString("hu-HU", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`;
@@ -98,7 +107,7 @@ export function buildMinutesDraft(m: MeetingDetailData): string {
 
   lines.push(`# Jegyzőkönyv — ${m.title}`);
   lines.push("");
-  lines.push(`**Időpont:** ${fmtDateTime(m.date)} ${m.time}`);
+  lines.push(`**Időpont:** ${fmtDate(m.date)} ${m.time}`);
   if (m.location) lines.push(`**Helyszín:** ${m.location}`);
   if (m.format) lines.push(`**A közgyűlés formája:** ${FORMAT_LABEL[m.format] ?? m.format}`);
   lines.push(`**Megnyitás:** ${fmtDateTime(m.startedAt)} · **Berekesztés:** ${fmtDateTime(m.endedAt)}`);


### PR DESCRIPTION
Found while running the P4 multi-device test on production: **Közgyűlés mód could never surface a vote.** The presenter and companion both gate the vote UI on `agendaItem.voteId`, but nothing ever wrote one — the agenda editor only had `title`/`description`. So device-voting in a live session was unreachable.

## Fix
- **`AgendaItem` gains optional `voteId`.** The agenda editor renders a per-point vote selector populated from the meeting's votes ("Nincs kapcsolódó szavazás" + each vote title). `meeting-detail` passes `meeting.votes` in and preserves an existing `voteId` when re-opening the editor. The meeting `PATCH` already stores the agenda JSON verbatim, so **no API change**.
  - Result: a point with a linked vote now shows **"Szavazás megnyitása"** in the presenter, and the **live vote card** on companions — closing the device-voting loop.
- **Minutes date fix:** the `Időpont` line ran the date through a date+time formatter and *then* appended `meeting.time`, rendering `...június 28. 18:00 18:00`. Split out a date-only formatter → `...június 28. 18:00`. (Spotted in the live P4 draft on prod.)
- i18n (hu+en).

## Verification
- **275 tests pass**; tsc + lint clean.
- P4 itself was verified live on production earlier (adjourn → auto-draft → `?tab=minutes` → editor/preview/signature panel all correct).
- After this merges + deploys, we run the **full multi-device demo**: link the two open votes to their agenda points, then presenter opens a vote → companion casts from phone → tally → close → result → adjourn → minutes draft now shows the resolutions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)