### PR TITLE
feat(voting): presence gate — owners can only vote if checked in

### DIFF
--- a/src/app/api/voting/meetings/[id]/check-in/route.ts
+++ b/src/app/api/voting/meetings/[id]/check-in/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireBuildingContext } from "@/lib/auth";
+import { requireFeature, FeatureGateError } from "@/lib/feature-gate";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * POST /api/voting/meetings/[id]/check-in
+ *
+ * Self check-in: a member registers their OWN owned unit(s) as present for a
+ * LIVE assembly. This is what makes "you can only vote if present" work for
+ * remote/hybrid attendees — the companion calls it on joining the live view,
+ * the same way the board uses "Érkeztetés" for people in the room.
+ *
+ * Only owners have votable units, so we check in the caller's OWNER units.
+ * Idempotent (upsert). No body.
+ */
+export async function POST(_request: NextRequest, context: RouteContext) {
+  try {
+    const { userId, buildingId } = await requireBuildingContext();
+
+    try {
+      await requireFeature(buildingId, "voting");
+    } catch (err) {
+      if (err instanceof FeatureGateError) {
+        return NextResponse.json({ error: err.message, upgrade: true }, { status: 403 });
+      }
+      throw err;
+    }
+
+    const { id: meetingId } = await context.params;
+    const meeting = await prisma.meeting.findUnique({
+      where: { id: meetingId },
+      select: { id: true, buildingId: true, liveStatus: true },
+    });
+    if (!meeting || meeting.buildingId !== buildingId) {
+      return NextResponse.json({ error: "Meeting not found" }, { status: 404 });
+    }
+    // Self check-in is only meaningful while the session is running.
+    if (meeting.liveStatus !== "LIVE") {
+      return NextResponse.json({ error: "Meeting is not live" }, { status: 400 });
+    }
+
+    // The caller's owned units in this building (only owners may vote — Tht. §38).
+    const ownerUnits = await prisma.unitUser.findMany({
+      where: { userId, relationship: "OWNER", unit: { buildingId } },
+      select: { unitId: true },
+    });
+
+    if (ownerUnits.length === 0) {
+      // Tenant/observer — present but no votable unit. Not an error.
+      return NextResponse.json({ checkedInUnitIds: [] });
+    }
+
+    await prisma.$transaction(
+      ownerUnits.map((u) =>
+        prisma.meetingAttendance.upsert({
+          where: { meetingId_unitId: { meetingId, unitId: u.unitId } },
+          update: { checkedIn: true, checkedInAt: new Date(), checkedOutAt: null },
+          create: { meetingId, unitId: u.unitId, checkedIn: true },
+        }),
+      ),
+    );
+
+    return NextResponse.json({ checkedInUnitIds: ownerUnits.map((u) => u.unitId) });
+  } catch (error) {
+    console.error("Failed to self check-in:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/voting/votes/[id]/ballot/route.ts
+++ b/src/app/api/voting/votes/[id]/ballot/route.ts
@@ -155,6 +155,20 @@ export async function POST(request: NextRequest, context: RouteContext) {
         return NextResponse.json({ error: "No unit found in this building" }, { status: 400 });
       }
       unitId = userUnit.unitId;
+
+      // Presence gate: for a vote held inside a meeting, the owner's unit must
+      // be checked in (présent). The companion self-checks-in on joining the
+      // live view; the board uses "Érkeztetés" for people in the room. Proxy
+      // (represented) and board on-behalf casts have their own paths above and
+      // are intentionally not gated here.
+      if (vote.meetingId) {
+        const attendance = await prisma.meetingAttendance.findUnique({
+          where: { meetingId_unitId: { meetingId: vote.meetingId, unitId } },
+        });
+        if (!attendance || !attendance.checkedIn || attendance.checkedOutAt) {
+          return NextResponse.json({ error: "NOT_CHECKED_IN" }, { status: 403 });
+        }
+      }
     }
 
     // Check if this unit already voted

--- a/src/components/voting/assembly-companion.tsx
+++ b/src/components/voting/assembly-companion.tsx
@@ -75,6 +75,14 @@ export function AssemblyCompanion({
 
   useAssemblyStream(meeting.id, () => router.refresh());
 
+  // Self check-in on joining the live view: registers the owner's unit(s) as
+  // present so they're allowed to vote (the remote-attendee equivalent of the
+  // board's "Érkeztetés"). Idempotent server-side; fire-and-forget.
+  useEffect(() => {
+    if (meeting.liveStatus !== "LIVE") return;
+    fetch(`/api/voting/meetings/${meeting.id}/check-in`, { method: "POST" }).catch(() => {});
+  }, [meeting.id, meeting.liveStatus]);
+
   const agenda = parseAgenda(meeting.agenda);
   const idx = Math.min(meeting.currentAgendaIndex, Math.max(0, agenda.length - 1));
   const point = agenda[idx];
@@ -115,7 +123,7 @@ export function AssemblyCompanion({
       });
       if (!res.ok) {
         const d = await res.json().catch(() => ({}));
-        toast.error(d.error || t("actionFailed"));
+        toast.error(d.error === "NOT_CHECKED_IN" ? t("notPresent") : d.error || t("actionFailed"));
         return;
       }
       const fresh = await fetch(`/api/voting/votes/${voteId}`, { cache: "no-store" });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2047,6 +2047,7 @@
   "assembly": {
     "presenterTitle": "Assembly mode",
     "actionFailed": "The action failed.",
+    "notPresent": "You must be present to vote. Open the live view, or ask the chair to check you in.",
     "closedHeading": "Assembly adjourned",
     "closedBody": "The minutes draft is available on the meeting page.",
     "closedDraftNote": "The system prepared a minutes draft from the votes and discussion — review it and have it authenticated.",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2047,6 +2047,7 @@
   "assembly": {
     "presenterTitle": "Közgyűlés mód",
     "actionFailed": "A művelet nem sikerült.",
+    "notPresent": "A szavazáshoz jelen kell lennie. Nyissa meg az élő követést, vagy kérje az érkeztetést a levezető elnöktől.",
     "closedHeading": "Közgyűlés berekesztve",
     "closedBody": "A jegyzőkönyv-vázlat elérhető a közgyűlés oldalán.",
     "closedDraftNote": "A rendszer a szavazások és a hozzászólások alapján elkészítette a jegyzőkönyv-tervezetet — ellenőrizze és hitelesíttesse.",

--- a/tests/integration/assembly-attendance-gate.test.ts
+++ b/tests/integration/assembly-attendance-gate.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Presence gate: in a live meeting an owner may only cast once their unit is
+ * checked in. The companion self-checks-in on joining; here we exercise the
+ * server: cast blocked → self check-in → cast allowed.
+ */
+const { ctxMock } = vi.hoisted(() => ({ ctxMock: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  requireBuildingContext: ctxMock,
+  getCurrentUser: vi.fn(),
+  auth: vi.fn(),
+}));
+vi.mock("@/lib/feature-gate", () => ({
+  requireFeature: vi.fn().mockResolvedValue(undefined),
+  FeatureGateError: class FeatureGateError extends Error {},
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimitMutationOrRespond: vi.fn().mockResolvedValue(null),
+}));
+
+const { POST: ballotPOST } = await import("@/app/api/voting/votes/[id]/ballot/route");
+const { POST: checkInPOST } = await import("@/app/api/voting/meetings/[id]/check-in/route");
+
+beforeEach(() => ctxMock.mockReset());
+
+async function liveMeetingWithVote() {
+  const { building } = await makeBuilding();
+  const owner = await makeUser({ buildingId: building.id, role: "OWNER" });
+  const unit = await prisma.unit.create({
+    data: { number: "1", floor: 1, ownershipShare: "0.5000", size: "60.00", buildingId: building.id },
+  });
+  await prisma.unitUser.create({
+    data: { userId: owner.id, unitId: unit.id, relationship: "OWNER", isPrimaryContact: true },
+  });
+  const meeting = await prisma.meeting.create({
+    data: { title: "Live", date: new Date(), time: "18:00", buildingId: building.id, createdById: owner.id, liveStatus: "LIVE" },
+  });
+  const vote = await prisma.vote.create({
+    data: {
+      buildingId: building.id, title: "V", voteType: "YES_NO", majorityType: "SIMPLE_MAJORITY",
+      isSecret: false, status: "OPEN", quorumRequired: 0.5, deadline: new Date("2099-12-31"),
+      createdById: owner.id, meetingId: meeting.id,
+    },
+  });
+  const option = await prisma.voteOption.create({ data: { voteId: vote.id, label: "Igen", sortOrder: 0 } });
+  return { building, owner, unit, meeting, vote, option };
+}
+
+function asOwner(buildingId: string, userId: string) {
+  ctxMock.mockResolvedValue({ userId, buildingId, role: "OWNER", ownsAnyUnit: true, isProfessional: false, isChair: false, isAuditor: false });
+}
+
+const ballotReq = (optionId: string) =>
+  new NextRequest("http://test/x", { method: "POST", body: JSON.stringify({ optionId }) });
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("assembly presence gate", () => {
+  it("blocks a self-cast when the unit is not checked in, allows it after self check-in", async () => {
+    const { building, owner, meeting, vote, option } = await liveMeetingWithVote();
+    asOwner(building.id, owner.id);
+
+    // Not present yet → blocked.
+    const blocked = await ballotPOST(ballotReq(option.id), params(vote.id));
+    expect(blocked.status).toBe(403);
+    expect((await blocked.json()).error).toBe("NOT_CHECKED_IN");
+
+    // Self check-in.
+    const ci = await checkInPOST(new NextRequest("http://test/x", { method: "POST" }), params(meeting.id));
+    expect(ci.status).toBe(200);
+    expect((await ci.json()).checkedInUnitIds).toHaveLength(1);
+
+    // Now allowed.
+    const ok = await ballotPOST(ballotReq(option.id), params(vote.id));
+    expect(ok.status).toBe(201);
+  });
+
+  it("self check-in is rejected when the meeting is not live", async () => {
+    const { building, owner, meeting } = await liveMeetingWithVote();
+    await prisma.meeting.update({ where: { id: meeting.id }, data: { liveStatus: "SCHEDULED" } });
+    asOwner(building.id, owner.id);
+    const res = await checkInPOST(new NextRequest("http://test/x", { method: "POST" }), params(meeting.id));
+    expect(res.status).toBe(400);
+  });
+
+  it("does not gate a standalone vote (no meeting)", async () => {
+    const { building, owner, vote } = await liveMeetingWithVote();
+    await prisma.vote.update({ where: { id: vote.id }, data: { meetingId: null } });
+    const option = await prisma.voteOption.findFirst({ where: { voteId: vote.id } });
+    asOwner(building.id, owner.id);
+    const res = await ballotPOST(ballotReq(option!.id), params(vote.id));
+    expect(res.status).toBe(201); // no presence gate off-meeting
+  });
+});


### PR DESCRIPTION
**Issue #1 from the live prod test:** an owner could cast a ballot in a live meeting without being present.

## Fix
- **`POST /api/voting/meetings/[id]/check-in`** (new) — self check-in: a member registers their own owner-units as present for a **LIVE** meeting (idempotent upsert). The remote/hybrid equivalent of the board's "Érkeztetés".
- The **companion self-checks-in on joining** the live follower view (fire-and-forget `useEffect`).
- The **ballot endpoint gates the self-cast path**: for a vote held inside a meeting, the unit must be `checkedIn && !checkedOutAt`, else **403 `NOT_CHECKED_IN`**. Deliberately **not** gated: standalone (off-meeting) votes, proxy casts (represented), and board on-behalf casts.
- Companion maps `NOT_CHECKED_IN` → a translated message (hu+en).

## Decision context
Chosen policy (your call): *self check-in on joining live* — works for both in-person (board check-in) and remote/hybrid (companion self check-in), without forcing the chair to check in every online attendee.

## Verification
- New tests: cast blocked → self check-in → cast allowed; check-in rejected when not live; standalone vote ungated. **278 tests pass**, tsc + lint clean.

Part of the post-demo fixes (with proxy UI, PDF worker, signatures coming separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)