### PR TITLE
feat(voting): proxy (meghatalmazás) voting in the companion

### DIFF
--- a/src/app/api/voting/votes/[id]/route.ts
+++ b/src/app/api/voting/votes/[id]/route.ts
@@ -74,6 +74,61 @@ export async function GET(request: NextRequest, context: RouteContext) {
         })
       : null;
 
+    // Units the caller may cast for via an active proxy (meghatalmazás) —
+    // the grantor's owner-units in this building, for proxies valid now and
+    // in scope for this vote. Each carries whether it has already voted.
+    const now = new Date();
+    const proxyAssignments = await prisma.proxyAssignment.findMany({
+      where: {
+        granteeId: userId,
+        validFrom: { lte: now },
+        AND: [
+          { OR: [{ voteId: id }, { voteId: null }] },
+          { OR: [{ validUntil: null }, { validUntil: { gte: now } }] },
+        ],
+      },
+      select: {
+        grantor: {
+          select: {
+            name: true,
+            unitUsers: {
+              where: { relationship: "OWNER", unit: { buildingId } },
+              select: { unit: { select: { id: true, number: true, ownershipShare: true } } },
+            },
+          },
+        },
+      },
+    });
+
+    const proxyUnitMap = new Map<
+      string,
+      { unitId: string; unitNumber: string; grantorName: string; weight: number }
+    >();
+    for (const pa of proxyAssignments) {
+      for (const uu of pa.grantor.unitUsers) {
+        if (!proxyUnitMap.has(uu.unit.id)) {
+          proxyUnitMap.set(uu.unit.id, {
+            unitId: uu.unit.id,
+            unitNumber: uu.unit.number,
+            grantorName: pa.grantor.name,
+            weight: Number(uu.unit.ownershipShare),
+          });
+        }
+      }
+    }
+    const proxyUnitIds = [...proxyUnitMap.keys()];
+    const proxyBallots = proxyUnitIds.length
+      ? await prisma.ballot.findMany({
+          where: { voteId: id, unitId: { in: proxyUnitIds } },
+          select: { unitId: true, optionId: true },
+        })
+      : [];
+    const proxyVotedBy = new Map(proxyBallots.map((b) => [b.unitId, b.optionId]));
+    const proxyUnits = [...proxyUnitMap.values()].map((u) => ({
+      ...u,
+      votedOptionId: proxyVotedBy.get(u.unitId) ?? null,
+    }));
+
     // Results only available when vote is closed
     let results = null;
     if (vote.status === "CLOSED") {
@@ -99,6 +154,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         ? { optionId: myBallot.optionId, receiptHash: myBallot.receiptHash }
         : null,
       myWeight: unit ? Number(unit.ownershipShare) : 0,
+      proxyUnits,
       results,
       ballots: vote.ballots.map((b) => ({
         id: b.id,

--- a/src/components/voting/assembly-companion.tsx
+++ b/src/components/voting/assembly-companion.tsx
@@ -26,12 +26,21 @@ function parseAgenda(raw: unknown): AgendaItem[] {
   });
 }
 
+interface ProxyUnit {
+  unitId: string;
+  unitNumber: string;
+  grantorName: string;
+  weight: number;
+  votedOptionId: string | null;
+}
+
 interface VoteDetail {
   id: string;
   status: string;
   myWeight: number;
   myBallot: { optionId: string } | null;
   options: { id: string; label: string }[];
+  proxyUnits: ProxyUnit[];
 }
 
 export function AssemblyCompanion({
@@ -45,6 +54,8 @@ export function AssemblyCompanion({
   const router = useRouter();
   const [detail, setDetail] = useState<VoteDetail | null>(null);
   const [picked, setPicked] = useState<string | null>(null);
+  const [proxyPicked, setProxyPicked] = useState<Record<string, string>>({});
+  const [proxyBusy, setProxyBusy] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [composing, setComposing] = useState(false);
   const [qText, setQText] = useState("");
@@ -131,6 +142,30 @@ export function AssemblyCompanion({
       router.refresh();
     } finally {
       setBusy(false);
+    }
+  }
+
+  // Cast on behalf of a unit the user holds a proxy (meghatalmazás) for.
+  async function castProxy(unitId: string) {
+    const optionId = proxyPicked[unitId];
+    if (!optionId || !voteId || proxyBusy) return;
+    setProxyBusy(unitId);
+    try {
+      const res = await fetch(`/api/voting/votes/${voteId}/ballot`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ optionId, proxyForUnitId: unitId }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        toast.error(d.error || t("actionFailed"));
+        return;
+      }
+      const fresh = await fetch(`/api/voting/votes/${voteId}`, { cache: "no-store" });
+      if (fresh.ok) setDetail(await fresh.json());
+      router.refresh();
+    } finally {
+      setProxyBusy(null);
     }
   }
 
@@ -228,6 +263,53 @@ export function AssemblyCompanion({
             <p className="mt-3 text-center text-[12px]" style={{ color: "color-mix(in srgb, var(--color-bg) 55%, transparent)" }}>
               {t("companionTallyHidden")}
             </p>
+          </div>
+        )}
+
+        {/* proxy voting (meghatalmazás) — cast for units the user represents */}
+        {pointVote && openNow && detail && detail.proxyUnits.length > 0 && (
+          <div className="rounded-2xl p-4 mb-4" style={{ background: "var(--color-card)", border: "1px solid color-mix(in srgb, var(--color-ink) 11%, transparent)" }}>
+            <div className="font-mono text-[10.5px] uppercase tracking-wider mb-3" style={{ color: "var(--color-muted)" }}>
+              {t("companionProxyTitle")}
+            </div>
+            {detail.proxyUnits.map((pu) => {
+              const voted = detail.options.find((o) => o.id === pu.votedOptionId);
+              return (
+                <div key={pu.unitId} className="mb-3.5 pb-3.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--color-ink) 7%, transparent)" }}>
+                  <div className="text-[13px] font-semibold mb-2">
+                    {pu.grantorName} <span className="font-mono text-[11px] font-normal" style={{ color: "var(--color-muted)" }}>· {pu.unitNumber} · {(pu.weight * 100).toFixed(2)}%</span>
+                  </div>
+                  {voted ? (
+                    <div className="flex items-center gap-2 rounded-lg px-3 py-2 text-[13px] font-semibold" style={{ background: "color-mix(in srgb, var(--color-moss) 14%, transparent)", color: "var(--color-moss)" }}>
+                      ✓ {t("companionVoted", { label: voted.label })}
+                    </div>
+                  ) : (
+                    <>
+                      <div className="flex flex-wrap gap-1.5 mb-2">
+                        {detail.options.map((o) => {
+                          const sel = proxyPicked[pu.unitId] === o.id;
+                          return (
+                            <button key={o.id} onClick={() => setProxyPicked((p) => ({ ...p, [pu.unitId]: o.id }))}
+                              className="rounded-lg px-3 py-2 text-[13px] font-semibold"
+                              style={{
+                                border: `1.5px solid ${sel ? "var(--color-ink)" : "color-mix(in srgb, var(--color-ink) 14%, transparent)"}`,
+                                background: sel ? "color-mix(in srgb, var(--color-ink) 8%, transparent)" : "transparent",
+                              }}>
+                              {o.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <button onClick={() => castProxy(pu.unitId)} disabled={!proxyPicked[pu.unitId] || proxyBusy === pu.unitId}
+                        className="w-full rounded-lg py-2.5 text-[13px] font-bold disabled:opacity-50"
+                        style={{ background: "var(--color-ink)", color: "var(--color-bg)" }}>
+                        {t("companionProxyCast", { name: pu.grantorName })}
+                      </button>
+                    </>
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2097,6 +2097,8 @@
     "companionFollowing": "Now discussing · {n}/{total}",
     "companionYourShare": "Your share:",
     "companionVoted": "Vote recorded · {label}",
+    "companionProxyTitle": "By proxy",
+    "companionProxyCast": "Cast for {name}",
     "castVote": "Cast vote",
     "companionTallyHidden": "The result is hidden until close.",
     "companionAsk": "Question",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2097,6 +2097,8 @@
     "companionFollowing": "Most tárgyalt · {n}/{total}",
     "companionYourShare": "Az Ön hányada:",
     "companionVoted": "Szavazata rögzítve · {label}",
+    "companionProxyTitle": "Meghatalmazással",
+    "companionProxyCast": "Leadom {name} nevében",
     "castVote": "Szavazat leadása",
     "companionTallyHidden": "Az eredmény a lezárásig rejtett.",
     "companionAsk": "Kérdés",

--- a/tests/integration/assembly-proxy-voting.test.ts
+++ b/tests/integration/assembly-proxy-voting.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Proxy (meghatalmazás) voting: a grantee sees the grantor's unit as votable
+ * and casts on its behalf with proxyForUnitId. The grantor's own presence is
+ * NOT required (they're represented).
+ */
+const { ctxMock } = vi.hoisted(() => ({ ctxMock: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ requireBuildingContext: ctxMock, getCurrentUser: vi.fn(), auth: vi.fn() }));
+vi.mock("@/lib/feature-gate", () => ({
+  requireFeature: vi.fn().mockResolvedValue(undefined),
+  FeatureGateError: class FeatureGateError extends Error {},
+}));
+vi.mock("@/lib/rate-limit", () => ({ rateLimitMutationOrRespond: vi.fn().mockResolvedValue(null) }));
+
+const { GET: voteGET } = await import("@/app/api/voting/votes/[id]/route");
+const { POST: ballotPOST } = await import("@/app/api/voting/votes/[id]/ballot/route");
+
+beforeEach(() => ctxMock.mockReset());
+
+async function scenario() {
+  const { building } = await makeBuilding();
+  const grantor = await makeUser({ buildingId: building.id, role: "OWNER" });
+  const grantee = await makeUser({ buildingId: building.id, role: "OWNER" });
+  const grantorUnit = await prisma.unit.create({
+    data: { number: "2", floor: 1, ownershipShare: "0.4000", size: "55.00", buildingId: building.id },
+  });
+  await prisma.unitUser.create({
+    data: { userId: grantor.id, unitId: grantorUnit.id, relationship: "OWNER", isPrimaryContact: true },
+  });
+  // The grantee is also an owner in the building (proxies go to fellow owners).
+  const granteeUnit = await prisma.unit.create({
+    data: { number: "3", floor: 1, ownershipShare: "0.3000", size: "50.00", buildingId: building.id },
+  });
+  await prisma.unitUser.create({
+    data: { userId: grantee.id, unitId: granteeUnit.id, relationship: "OWNER", isPrimaryContact: true },
+  });
+  await prisma.proxyAssignment.create({ data: { grantorId: grantor.id, granteeId: grantee.id } });
+  const meeting = await prisma.meeting.create({
+    data: { title: "Live", date: new Date(), time: "18:00", buildingId: building.id, createdById: grantor.id, liveStatus: "LIVE" },
+  });
+  const vote = await prisma.vote.create({
+    data: {
+      buildingId: building.id, title: "V", voteType: "YES_NO", majorityType: "SIMPLE_MAJORITY",
+      isSecret: false, status: "OPEN", quorumRequired: 0.5, deadline: new Date("2099-12-31"),
+      createdById: grantor.id, meetingId: meeting.id,
+    },
+  });
+  const option = await prisma.voteOption.create({ data: { voteId: vote.id, label: "Igen", sortOrder: 0 } });
+  return { building, grantor, grantee, grantorUnit, vote, option };
+}
+
+function asGrantee(buildingId: string, userId: string) {
+  ctxMock.mockResolvedValue({ userId, buildingId, role: "OWNER", ownsAnyUnit: true, isProfessional: false, isChair: false, isAuditor: false });
+}
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("proxy voting", () => {
+  it("exposes the grantor's unit to the grantee and casts on its behalf (no presence needed)", async () => {
+    const { building, grantee, grantorUnit, vote, option } = await scenario();
+    asGrantee(building.id, grantee.id);
+
+    // GET surfaces the proxied unit.
+    const detail = await (await voteGET(new NextRequest("http://test/x"), params(vote.id))).json();
+    expect(detail.proxyUnits).toHaveLength(1);
+    expect(detail.proxyUnits[0].unitId).toBe(grantorUnit.id);
+    expect(detail.proxyUnits[0].votedOptionId).toBeNull();
+
+    // Cast on behalf — grantor unit is NOT checked in, but proxy is allowed.
+    const res = await ballotPOST(
+      new NextRequest("http://test/x", { method: "POST", body: JSON.stringify({ optionId: option.id, proxyForUnitId: grantorUnit.id }) }),
+      params(vote.id),
+    );
+    expect(res.status).toBe(201);
+
+    // GET now shows the proxied unit as voted.
+    const after = await (await voteGET(new NextRequest("http://test/x"), params(vote.id))).json();
+    expect(after.proxyUnits[0].votedOptionId).toBe(option.id);
+  });
+});


### PR DESCRIPTION
**Issue #2 from the live prod test:** proxies could be *granted* but never *used* — the ballot endpoint accepted `proxyForUnitId` and validated the `ProxyAssignment`, but no UI ever sent it.

## Fix
- **`GET /api/voting/votes/[id]`** now returns **`proxyUnits`**: the grantor owner-units the caller may cast for (proxies valid now + in scope for this vote), each with grantor name, unit number, ownership weight, and `votedOptionId`.
- **Companion** renders a **"Meghatalmazással"** section under the live vote card — each represented unit gets its own option picker + **"Leadom {name} nevében"** button, casting with `proxyForUnitId`. Units already voted show the recorded choice.
- A proxy cast does **not** require the grantor to be checked in (they're represented); only the self-vote path is presence-gated (#87).
- i18n (hu+en).

## Verification
- Test: GET surfaces the proxied unit → grantee casts on its behalf (grantor not present) → GET reflects the recorded vote. **279 tests pass**, tsc + lint clean.

## Tracked follow-up (your "proxy now, multi-unit next" call)
Per-unit ballots for a single owner of **multiple** units, or one grantee holding **several** proxies casting each separately — the current self-cast still uses one combined ballot. Recorded as the multi-unit follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)