### PR TITLE
fix(worker): neutralize server-only so the worker stops crash-looping

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,3 +1,6 @@
+// MUST be first: neutralizes `server-only` so the shared libs the worker
+// reuses don't crash this non-RSC process at startup.
+import "./server-only-shim";
 import { Worker } from "bullmq";
 import Redis from "ioredis";
 import { processNotificationJob } from "./jobs";

--- a/worker/server-only-shim.ts
+++ b/worker/server-only-shim.ts
@@ -1,0 +1,28 @@
+/**
+ * Neutralize `server-only` / `client-only` for the worker process.
+ *
+ * Many shared libs the worker reuses (audit, notifications, report data
+ * builders, …) start with `import "server-only"`. That package is a Next.js
+ * client-boundary guard: outside a React Server build it throws
+ *   "This module cannot be imported from a Client Component module."
+ * The BullMQ worker is a plain Node/tsx process — not an RSC context — so the
+ * guard fires and crashes the whole worker at startup, leaving every queue
+ * (reports, notifications, voting, scheduled) unconsumed.
+ *
+ * The guard is meaningless here (there is no client bundle), so we intercept
+ * the module load and return an empty module. This MUST be imported before any
+ * app code so the patch is installed first — see worker/index.ts.
+ */
+import Module from "module";
+
+type Loader = (request: string, parent: unknown, isMain: boolean) => unknown;
+
+const mod = Module as unknown as { _load: Loader };
+const original = mod._load;
+
+mod._load = function (request: string, parent: unknown, isMain: boolean) {
+  if (request === "server-only" || request === "client-only") {
+    return {};
+  }
+  return original.call(this, request, parent, isMain);
+};


### PR DESCRIPTION
**Root cause of issue #3 (PDFs stuck PENDING)** — and it's bigger than PDFs: **the whole BullMQ worker has been crash-looping in prod**, so *no* queue was being consumed (reports, **email/notifications**, voting, scheduled).

## Why
The worker (`tsx worker/index.ts`) transitively imports shared libs — `audit`, `notifications`, the report-data builders, etc. — that start with `import "server-only"`. That package is a Next.js client-boundary guard; outside a React Server build it throws:

```
Error: This module cannot be imported from a Client Component module.
  at .../server-only/index.js
  at .../src/lib/audit.ts:1:8
```

The worker is a plain Node/tsx process — not an RSC context — so the guard fired and killed it at boot. `restart: unless-stopped` relaunched it straight back into the same crash. A report row gets created (`PENDING`) and enqueued, but nothing ever consumes it.

## Fix (worker-scoped, app untouched)
- **`worker/server-only-shim.ts`** patches `Module._load` to return an empty module for `server-only` / `client-only`. The guard is meaningless in the worker (there's no client bundle); the Next app keeps the real guard.
- **`worker/index.ts`** imports the shim **first**, before any app code, so the patch is installed before the guarded modules load (works under tsx's CJS execution; verified by the order in the stack trace).

## Verification
- Local: `tsx worker/index.ts` now logs **"Worker started, listening for jobs on 'notifications', 'voting', 'scheduled', and 'reports' queues…"** instead of throwing the error above.
- After this deploys, the report job will actually render → PDF buttons resolve, and queued email/notifications flow again.

Unblocks the signature-in-PDF work (#4) since the minutes PDF is generated by this worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)