### PR TITLE
fix(voting): signatures on the jegyzőkönyv — on-screen mirror + revalidate

### DIFF
--- a/src/app/actions/voting.ts
+++ b/src/app/actions/voting.ts
@@ -92,7 +92,7 @@ export async function createVote(input: CreateVoteInput): Promise<ActionResult> 
       });
     }
 
-    revalidatePath("/voting");
+    revalidatePath("/[locale]/voting", "page");
     return { success: true };
   } catch (error) {
     console.error("Failed to create vote:", error);
@@ -137,7 +137,7 @@ export async function saveMinutes(
       newValue: { minutesLength: minutes.length },
     });
 
-    revalidatePath(`/voting/meetings/${meetingId}`);
+    revalidatePath("/[locale]/voting/meetings/[id]", "page");
     return { success: true };
   } catch (error) {
     console.error("Failed to save minutes:", error);
@@ -206,7 +206,7 @@ export async function signMeetingMinutes(
       newValue: { role: signatureRole },
     });
 
-    revalidatePath(`/voting/meetings/${meetingId}`);
+    revalidatePath("/[locale]/voting/meetings/[id]", "page");
     return { success: true };
   } catch (error) {
     console.error("Failed to sign minutes:", error);

--- a/src/components/voting/meeting-detail.tsx
+++ b/src/components/voting/meeting-detail.tsx
@@ -29,6 +29,7 @@ import { AgendaEditor, AgendaItem } from "./agenda-editor";
 import { CreateVoteModal } from "./create-vote-modal";
 import { QuickVotePanel } from "./quick-vote-panel";
 import { MinutesSignaturesPanel } from "./minutes-signatures-panel";
+import { MinutesSignatureBlock } from "./minutes-signature-block";
 import type { MeetingDetailData } from "@/lib/dal";
 
 interface MeetingDetailProps {
@@ -485,6 +486,7 @@ export function MeetingDetail({ meeting }: MeetingDetailProps) {
               updatedBy={meeting.minutesUpdatedBy}
             />
           )}
+          <MinutesSignatureBlock signatures={meeting.signatures} />
           <MinutesSignaturesPanel
             meetingId={meeting.id}
             signatures={meeting.signatures}

--- a/src/components/voting/minutes-signature-block.tsx
+++ b/src/components/voting/minutes-signature-block.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ShieldCheck } from "lucide-react";
+import type { MeetingMinutesSignatureData } from "@/lib/dal";
+
+const ROLES: { key: MeetingMinutesSignatureData["role"]; labelKey: string }[] = [
+  { key: "CHAIR", labelKey: "minutesSignChair" },
+  { key: "AUTHENTICATOR_1", labelKey: "minutesSignAuth1" },
+  { key: "AUTHENTICATOR_2", labelKey: "minutesSignAuth2" },
+];
+
+/**
+ * Read-only signature footer for the on-screen jegyzőkönyv — mirrors the three
+ * authentication slots of the minutes PDF so the document on screen reflects
+ * who has signed. Signing itself happens in MinutesSignaturesPanel.
+ */
+export function MinutesSignatureBlock({
+  signatures,
+}: {
+  signatures: MeetingMinutesSignatureData[];
+}) {
+  const t = useTranslations("voting");
+  const byRole = new Map(signatures.map((s) => [s.role, s]));
+  const executed = byRole.size === 3;
+
+  return (
+    <div className="rounded-xl border border-ink/8 bg-card p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-mono text-xs uppercase tracking-wider text-ink">
+          {t("minutesSignatureDocTitle")}
+        </h3>
+        {executed && (
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-0.5 font-mono text-[10.5px] uppercase tracking-wider"
+            style={{
+              background: "color-mix(in srgb, var(--color-good) 20%, transparent)",
+              color: "var(--color-good)",
+            }}
+          >
+            <ShieldCheck className="h-3 w-3" />
+            {t("minutesExecuted")}
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-3">
+        {ROLES.map(({ key, labelKey }) => {
+          const sig = byRole.get(key);
+          return (
+            <div key={key} className="text-center">
+              <div
+                className="flex h-12 items-end justify-center pb-1 font-display text-lg"
+                style={{ color: sig ? "var(--color-ink)" : "var(--color-muted)" }}
+              >
+                {sig ? sig.signerName : ""}
+              </div>
+              <div className="border-t border-ink/25" />
+              <p className="mt-1.5 font-mono text-[10.5px] uppercase tracking-wider text-muted">
+                {t(labelKey)}
+              </p>
+              <p className="mt-0.5 text-[11px] text-ink-soft">
+                {sig
+                  ? new Date(sig.signedAt).toLocaleDateString("hu-HU", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })
+                  : t("minutesAwaitingSignature")}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1757,6 +1757,7 @@
     "minutesSignAuth1": "Authenticator 1",
     "minutesSignAuth2": "Authenticator 2",
     "minutesAwaitingSignature": "Awaiting signature",
+    "minutesSignatureDocTitle": "Authentication",
     "minutesExecuted": "Executed",
     "minutesSigned": "Signature recorded",
     "minutesSignBoardOnly": "Only board members can sign the minutes.",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -1757,6 +1757,7 @@
     "minutesSignAuth1": "Hitelesítő 1.",
     "minutesSignAuth2": "Hitelesítő 2.",
     "minutesAwaitingSignature": "Aláírásra vár",
+    "minutesSignatureDocTitle": "Hitelesítés",
     "minutesExecuted": "Hitelesítve",
     "minutesSigned": "Aláírás rögzítve",
     "minutesSignBoardOnly": "Jegyzőkönyv aláírására csak igazgatósági tagok jogosultak.",


### PR DESCRIPTION
**Issue #4 (signatures on the jegyzőkönyv)** — fully closed across all surfaces:

1. **Official PDF** — the minutes PDF already renders the three signature slots (signer + date + "Hitelesítve/Tervezet N/3"); it just never generated because the worker was crash-looping (fixed in #89). **Verified live**: a fresh minutes PDF returns `READY` (25.7 KB).

2. **On-screen document (new in this PR)** — a read-only **"Hitelesítés"** footer on the minutes tab (below the document, above the signing panel) mirrors the PDF: Levezető elnök / Hitelesítő 1. / Hitelesítő 2., each with signer name + date or "Aláírásra vár", plus a "Hitelesítve" badge when all three are in. So the on-screen jegyzőkönyv reflects who signed without opening the PDF. Signing still happens in the existing panel; this block is display-only, shown to editors and read-only viewers alike.

3. **Cache correctness** — the voting actions revalidated `/voting/...` (no `/[locale]`), so other clients' cached meeting views weren't busted after a save/sign. Switched to the dynamic route-pattern form (`/[locale]/voting`, `/[locale]/voting/meetings/[id]`).

## Verification
- tsc + lint clean; PDF confirmed generating on prod post-#89.
- Will re-verify the on-screen footer live once this deploys (demo meeting already has a CHAIR signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)