### PR TITLE
feat(reports): shared PDF design system + refresh all 7 templates

### DIFF
--- a/src/reports/lib/components.tsx
+++ b/src/reports/lib/components.tsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+import { Text, View, StyleSheet } from "@react-pdf/renderer";
+import { color, font, size, space } from "./theme";
+import { shortHash } from "./footer";
+import { formatDateTime } from "./format";
+
+const s = StyleSheet.create({
+  // ── Brand wordmark ──────────────────────────────────────────────
+  wordmark: { flexDirection: "row", alignItems: "center" },
+  mark: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    backgroundColor: color.ink,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  markLetter: { color: color.paper, fontSize: 13, fontWeight: 700, lineHeight: 1 },
+  wordmarkText: { marginLeft: 8 },
+  wordmarkName: { fontSize: 14, fontWeight: 700, letterSpacing: -0.2, color: color.ink, lineHeight: 1 },
+  wordmarkTag: {
+    fontSize: 6.5,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: color.muted,
+    marginTop: 2,
+  },
+
+  // ── Header band ─────────────────────────────────────────────────
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingBottom: 12,
+    marginBottom: 20,
+    borderBottomWidth: 2,
+    borderBottomColor: color.ink,
+    borderBottomStyle: "solid",
+  },
+  headerRight: { alignItems: "flex-end" },
+  reportType: {
+    fontSize: size.micro,
+    fontWeight: 700,
+    letterSpacing: 1.3,
+    textTransform: "uppercase",
+    color: color.ochre,
+  },
+  reportRef: { fontSize: size.tiny, color: color.muted, marginTop: 2 },
+
+  // ── Section title ───────────────────────────────────────────────
+  section: {
+    fontSize: size.h2,
+    fontWeight: 700,
+    color: color.ink,
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    marginTop: 20,
+    marginBottom: 9,
+    paddingBottom: 4,
+    borderBottomWidth: 0.75,
+    borderBottomColor: color.line,
+    borderBottomStyle: "solid",
+  },
+
+  // ── Status pill ─────────────────────────────────────────────────
+  pill: {
+    alignSelf: "flex-start",
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 11,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  pillDot: { width: 5, height: 5, borderRadius: 3, marginRight: 6 },
+  pillText: { fontSize: size.micro, fontWeight: 700, letterSpacing: 0.3 },
+
+  // ── Footer ──────────────────────────────────────────────────────
+  footer: {
+    position: "absolute",
+    bottom: 30,
+    left: space.pageX,
+    right: space.pageX,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingTop: 8,
+    borderTopWidth: 0.5,
+    borderTopColor: color.line,
+    borderTopStyle: "solid",
+    fontSize: size.tiny,
+    color: color.faint,
+    letterSpacing: 0.5,
+  },
+  pageNum: { fontFamily: font.mono },
+});
+
+/** Brand mark: dark rounded "K" + "Közös" wordmark + tagline. */
+export function Wordmark() {
+  return (
+    <View style={s.wordmark}>
+      <View style={s.mark}>
+        <Text style={s.markLetter}>K</Text>
+      </View>
+      <View style={s.wordmarkText}>
+        <Text style={s.wordmarkName}>Közös</Text>
+        <Text style={s.wordmarkTag}>társasházkezelés</Text>
+      </View>
+    </View>
+  );
+}
+
+/** Branded report header band: wordmark left, report type right. */
+export function ReportHeader({ reportType, reportRef }: { reportType: string; reportRef?: string }) {
+  return (
+    <View style={s.header} fixed>
+      <Wordmark />
+      <View style={s.headerRight}>
+        <Text style={s.reportType}>{reportType}</Text>
+        {reportRef ? <Text style={s.reportRef}>{reportRef}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+export function SectionTitle({ children, breakBefore }: { children: React.ReactNode; breakBefore?: boolean }) {
+  return (
+    <Text style={s.section} break={breakBefore}>
+      {children}
+    </Text>
+  );
+}
+
+type Tone = "positive" | "negative" | "neutral" | "warning";
+const TONE: Record<Tone, { bg: string; fg: string }> = {
+  positive: { bg: color.positiveTint, fg: color.positive },
+  negative: { bg: color.negativeTint, fg: color.negative },
+  warning: { bg: color.ochreTint, fg: color.ochre },
+  neutral: { bg: color.panel, fg: color.muted },
+};
+
+/** Small status pill — replaces the old full-width banners. */
+export function StatusPill({ tone, children }: { tone: Tone; children: React.ReactNode }) {
+  const c = TONE[tone];
+  return (
+    <View style={[s.pill, { backgroundColor: c.bg }]}>
+      <View style={[s.pillDot, { backgroundColor: c.fg }]} />
+      <Text style={[s.pillText, { color: c.fg }]}>{children}</Text>
+    </View>
+  );
+}
+
+export function ReportFooter({
+  buildingName,
+  generatedAt,
+  contentHash,
+}: {
+  buildingName: string;
+  generatedAt: Date;
+  contentHash: string;
+}) {
+  return (
+    <View style={s.footer} fixed>
+      <Text>
+        {buildingName} · {formatDateTime(generatedAt)} · hash {shortHash(contentHash)}
+      </Text>
+      <Text style={s.pageNum} render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`} />
+    </View>
+  );
+}

--- a/src/reports/lib/theme.ts
+++ b/src/reports/lib/theme.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared design tokens for all PDF reports (@react-pdf/renderer).
+ *
+ * react-pdf does NOT support CSS `color-mix()`, gradients, or var() — every
+ * value here is a literal so it actually renders. Tints are pre-mixed flat
+ * colors. Keep templates on these tokens so the report set stays consistent.
+ */
+
+export const color = {
+  ink: "#181a1c", // primary text
+  inkSoft: "#3c424a", // secondary text
+  muted: "#6c727a", // labels / tertiary
+  faint: "#9aa0a6", // placeholders
+  line: "#ddd8cd", // hairline rules
+  lineStrong: "#181a1c", // section rules
+  paper: "#ffffff", // page background
+  panel: "#f6f3ec", // warm panel / header band
+  panelEdge: "#e6e1d5", // panel border
+
+  // Brand + status (with pale tints, pre-mixed for react-pdf)
+  ochre: "#a8761c",
+  ochreTint: "#f6ecd7",
+  positive: "#4a5a3e", // passed / quorate
+  positiveTint: "#eaeee2",
+  negative: "#9e3b3b", // rejected / not quorate
+  negativeTint: "#f4e7e3",
+} as const;
+
+export const font = {
+  sans: "Manrope",
+  mono: "Courier",
+} as const;
+
+/** Type scale (pt). */
+export const size = {
+  title: 22,
+  h2: 10.5, // section titles (uppercase, tracked)
+  lead: 11,
+  body: 10.5,
+  small: 9.5,
+  micro: 9,
+  tiny: 8,
+} as const;
+
+export const space = {
+  pageX: 56,
+  pageTop: 44,
+  pageBottom: 64,
+} as const;
+
+/** Hungarian labels for vote majority types (PDF is a HU legal doc). */
+export const MAJORITY_LABEL: Record<string, string> = {
+  SIMPLE_MAJORITY: "Egyszerű többség",
+  TWO_THIRDS: "Minősített többség (2/3)",
+  FOUR_FIFTHS: "Minősített többség (4/5)",
+  UNANIMOUS: "Egyhangúság",
+  PLURALITY: "Relatív többség",
+};
+
+export function majorityLabel(t: string): string {
+  return MAJORITY_LABEL[t] ?? t;
+}

--- a/src/reports/templates/audit-slice.tsx
+++ b/src/reports/templates/audit-slice.tsx
@@ -1,13 +1,8 @@
 import * as React from "react";
-import {
-  Document,
-  Page,
-  Text,
-  View,
-  StyleSheet,
-} from "@react-pdf/renderer";
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
 import { formatDateTime, formatNumber } from "../lib/format";
-import { shortHash } from "../lib/footer";
+import { color, font, size, space } from "../lib/theme";
+import { ReportHeader, ReportFooter, SectionTitle, StatusPill } from "../lib/components";
 import type { AuditSliceData } from "@/lib/reports/audit-slice-data";
 
 export interface AuditSlicePdfProps extends AuditSliceData {
@@ -17,110 +12,76 @@ export interface AuditSlicePdfProps extends AuditSliceData {
 
 const styles = StyleSheet.create({
   page: {
-    padding: "44 40 60 40",
-    fontSize: 9,
-    color: "#16181a",
-    fontFamily: "Manrope",
-    lineHeight: 1.4,
+    paddingTop: space.pageTop,
+    paddingBottom: space.pageBottom,
+    paddingHorizontal: space.pageX,
+    fontSize: size.body,
+    color: color.ink,
+    fontFamily: font.sans,
+    lineHeight: 1.45,
   },
-  eyebrow: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    marginBottom: 6,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 500,
-    letterSpacing: -0.5,
-    lineHeight: 1.25,
-    marginBottom: 4,
-  },
-  buildingLine: {
-    fontSize: 11,
-    color: "#3a4048",
-    marginBottom: 12,
-  },
+
+  // Title block
+  title: { fontSize: size.title, fontWeight: 700, letterSpacing: -0.5, lineHeight: 1.2, marginBottom: 6 },
+  buildingLine: { fontSize: size.lead, fontWeight: 500, color: color.inkSoft, marginBottom: 12 },
+
   metaBlock: {
-    fontSize: 9,
-    color: "#3a4048",
+    fontSize: size.small,
+    color: color.inkSoft,
     marginBottom: 14,
-    backgroundColor: "#f6f3ec",
-    padding: 9,
-    borderRadius: 5,
+    backgroundColor: color.panel,
+    padding: 10,
+    borderRadius: 6,
     lineHeight: 1.5,
   },
-  truncated: {
-    fontSize: 9,
-    color: "#a04040",
-    marginBottom: 12,
-    paddingLeft: 8,
-    borderLeftWidth: 3,
-    borderLeftColor: "#a04040",
-  },
-  rowHeader: {
+  truncated: { marginBottom: 12 },
+
+  // Table
+  thRow: {
     flexDirection: "row",
     paddingBottom: 5,
     borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
+    borderBottomColor: color.lineStrong,
     borderBottomStyle: "solid",
-    fontSize: 8,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
   },
-  row: {
+  tr: {
     flexDirection: "row",
-    paddingTop: 4,
-    paddingBottom: 4,
+    paddingVertical: 4.5,
     borderBottomWidth: 0.5,
-    borderBottomColor: "#e8e6e1",
+    borderBottomColor: color.line,
     borderBottomStyle: "solid",
-    fontSize: 8.5,
+    fontSize: size.small,
   },
+  trZebra: { backgroundColor: color.panel },
   cellTime: { width: 90 },
   cellActor: { width: 110 },
   cellAction: { width: 60 },
   cellEntity: { width: 110 },
-  cellDiff: { flex: 1, color: "#3a4048" },
+  cellDiff: { flex: 1, color: color.inkSoft },
+
   manifestBox: {
     marginTop: 16,
-    padding: 9,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 5,
+    padding: 10,
+    borderWidth: 1,
+    borderColor: color.panelEdge,
+    borderStyle: "solid",
+    borderRadius: 8,
   },
   manifestLabel: {
-    fontSize: 8,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.9,
     textTransform: "uppercase",
     marginBottom: 3,
   },
-  manifestHash: {
-    fontFamily: "Courier",
-    fontSize: 8.5,
-    color: "#16181a",
-  },
-  manifestNote: {
-    fontSize: 8,
-    color: "#6c727a",
-    marginTop: 4,
-    lineHeight: 1.4,
-  },
-  emptyNote: { fontSize: 10, color: "#9a9c9f", marginTop: 12 },
-  footer: {
-    position: "absolute",
-    bottom: 28,
-    left: 40,
-    right: 40,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    fontSize: 8,
-    color: "#9a9c9f",
-    letterSpacing: 0.6,
-  },
-  pageNum: { fontFamily: "Courier" },
+  manifestHash: { fontFamily: font.mono, fontSize: size.small, color: color.ink },
+  manifestNote: { fontSize: size.micro, color: color.muted, marginTop: 4, lineHeight: 1.4 },
+
+  empty: { fontSize: size.small, color: color.faint, marginTop: 12 },
 });
 
 const ACTION_LABEL: Record<string, string> = {
@@ -136,7 +97,9 @@ export function AuditSlicePdf(props: AuditSlicePdfProps) {
       author={props.buildingName}
     >
       <Page size="A4" style={styles.page}>
-        <Text style={styles.eyebrow}>Audit napló kivonat · GDPR § 15</Text>
+        <ReportHeader reportType="Számviteli kivonat" reportRef="GDPR § 15" />
+
+        {/* Title block */}
         <Text style={styles.title}>
           {props.filters.fromLabel} – {props.filters.toLabel}
         </Text>
@@ -152,28 +115,28 @@ export function AuditSlicePdf(props: AuditSlicePdfProps) {
         </Text>
 
         {props.truncated && (
-          <Text style={styles.truncated}>
-            A találatok száma meghaladja a {formatNumber(props.rowLimit)}-as
-            korlátot. Csak a legfrissebb {formatNumber(props.rowLimit)} esemény
-            kerül megjelenítésre. Szűkítse a tartományt további részletekért.
-          </Text>
+          <View style={styles.truncated}>
+            <StatusPill tone="warning">
+              {`A találatok száma meghaladja a ${formatNumber(props.rowLimit)}-as korlátot. Csak a legfrissebb ${formatNumber(props.rowLimit)} esemény kerül megjelenítésre. Szűkítse a tartományt további részletekért.`}
+            </StatusPill>
+          </View>
         )}
 
+        {/* AUDIT EVENTS */}
+        <SectionTitle>Audit események</SectionTitle>
         {props.rows.length === 0 ? (
-          <Text style={styles.emptyNote}>
-            Nincs audit esemény a megadott tartományban.
-          </Text>
+          <Text style={styles.empty}>Nincs audit esemény a megadott tartományban.</Text>
         ) : (
           <View>
-            <View style={styles.rowHeader}>
+            <View style={styles.thRow}>
               <Text style={styles.cellTime}>Időpont</Text>
               <Text style={styles.cellActor}>Felhasználó</Text>
               <Text style={styles.cellAction}>Művelet</Text>
               <Text style={styles.cellEntity}>Entitás</Text>
               <Text style={styles.cellDiff}>Részletek</Text>
             </View>
-            {props.rows.map((r) => (
-              <View key={r.id} style={styles.row} wrap={false}>
+            {props.rows.map((r, i) => (
+              <View key={r.id} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]} wrap={false}>
                 <Text style={styles.cellTime}>
                   {new Date(r.createdAt).toLocaleString("hu-HU", {
                     year: "2-digit",
@@ -207,18 +170,11 @@ export function AuditSlicePdf(props: AuditSlicePdfProps) {
           </Text>
         </View>
 
-        <View style={styles.footer} fixed>
-          <Text>
-            {props.buildingName} · {formatDateTime(props.generatedAt)} · hash{" "}
-            {shortHash(props.contentHash)}
-          </Text>
-          <Text
-            style={styles.pageNum}
-            render={({ pageNumber, totalPages }) =>
-              `${pageNumber} / ${totalPages}`
-            }
-          />
-        </View>
+        <ReportFooter
+          buildingName={props.buildingName}
+          generatedAt={props.generatedAt}
+          contentHash={props.contentHash}
+        />
       </Page>
     </Document>
   );

--- a/src/reports/templates/finance-summary.tsx
+++ b/src/reports/templates/finance-summary.tsx
@@ -8,10 +8,10 @@ import {
 } from "@react-pdf/renderer";
 import {
   formatHUF,
-  formatDateTime,
   formatNumber,
 } from "../lib/format";
-import { shortHash } from "../lib/footer";
+import { color, font, size, space } from "../lib/theme";
+import { ReportHeader, ReportFooter, SectionTitle, StatusPill } from "../lib/components";
 import type { FinanceSummaryData } from "@/lib/reports/finance-summary-data";
 
 export interface FinanceSummaryPdfProps extends FinanceSummaryData {
@@ -21,113 +21,83 @@ export interface FinanceSummaryPdfProps extends FinanceSummaryData {
 
 const styles = StyleSheet.create({
   page: {
-    padding: "48 56 64 56",
-    fontSize: 10.5,
-    color: "#16181a",
-    fontFamily: "Manrope",
-    lineHeight: 1.4,
+    paddingTop: space.pageTop,
+    paddingBottom: space.pageBottom,
+    paddingHorizontal: space.pageX,
+    fontSize: size.body,
+    color: color.ink,
+    fontFamily: font.sans,
+    lineHeight: 1.45,
   },
-  eyebrow: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 500,
-    letterSpacing: -0.5,
-    lineHeight: 1.25,
-    marginBottom: 8,
-    color: "#16181a",
-  },
-  subtitle: {
-    fontSize: 11,
-    color: "#3a4048",
-    marginBottom: 4,
-  },
-  meta: {
-    fontSize: 10,
-    color: "#3a4048",
-    marginBottom: 24,
-  },
-  sectionHeader: {
-    fontSize: 11,
-    fontWeight: 700,
-    color: "#16181a",
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-    marginTop: 16,
-    marginBottom: 10,
-    paddingBottom: 4,
-    borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
-    borderBottomStyle: "solid",
-  },
+
+  // Title block
+  title: { fontSize: size.title, fontWeight: 700, letterSpacing: -0.5, lineHeight: 1.2, marginBottom: 6 },
+  buildingLine: { fontSize: size.lead, fontWeight: 500, color: color.inkSoft, marginBottom: 3 },
+  meta: { fontSize: size.small, color: color.muted, marginBottom: 14 },
+
+  // KPI row
   kpiRow: {
     flexDirection: "row",
-    marginBottom: 16,
+    marginBottom: 4,
     gap: 8,
   },
   kpiCell: {
     flex: 1,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: color.panelEdge,
+    borderStyle: "solid",
+    borderRadius: 8,
     padding: 12,
   },
   kpiLabel: {
-    fontSize: 8,
-    color: "#6c727a",
+    fontSize: size.tiny,
+    color: color.muted,
     letterSpacing: 1.1,
     textTransform: "uppercase",
     marginBottom: 4,
   },
   kpiValue: {
     fontSize: 16,
-    fontWeight: 500,
+    fontWeight: 700,
   },
   kpiSub: {
-    fontSize: 9,
-    color: "#6c727a",
+    fontSize: size.micro,
+    color: color.muted,
     marginTop: 2,
   },
-  good: { color: "#4a5a3e" },
-  bad: { color: "#a04040" },
-  rowHeader: {
+  good: { color: color.positive },
+  bad: { color: color.negative },
+
+  // Tables
+  thRow: {
     flexDirection: "row",
-    paddingBottom: 6,
+    paddingBottom: 5,
     borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
+    borderBottomColor: color.lineStrong,
     borderBottomStyle: "solid",
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
   },
-  row: {
+  tr: {
     flexDirection: "row",
-    paddingTop: 8,
-    paddingBottom: 8,
+    paddingVertical: 4.5,
     borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
+    borderBottomColor: color.line,
     borderBottomStyle: "solid",
+    fontSize: size.small,
   },
+  trZebra: { backgroundColor: color.panel },
   category: { flex: 3 },
   amount: { flex: 1, textAlign: "right", fontWeight: 500 },
-  share: { flex: 1, textAlign: "right", color: "#6c727a" },
-  topRow: {
-    flexDirection: "row",
-    paddingTop: 6,
-    paddingBottom: 6,
-    borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
-    borderBottomStyle: "solid",
-  },
-  topDate: { width: 60, color: "#6c727a", fontSize: 9 },
+  share: { flex: 1, textAlign: "right", color: color.muted },
+  topDate: { width: 60, color: color.muted, fontSize: size.micro },
   topDesc: { flex: 1 },
-  topCategory: { width: 90, color: "#6c727a", fontSize: 9 },
+  topCategory: { width: 90, color: color.muted, fontSize: size.micro },
   topAmount: { width: 80, textAlign: "right", fontWeight: 500 },
+
+  // Monthly trend
   trendRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -136,8 +106,8 @@ const styles = StyleSheet.create({
   },
   trendLabel: {
     width: 60,
-    fontSize: 9,
-    color: "#6c727a",
+    fontSize: size.micro,
+    color: color.muted,
   },
   trendBars: {
     flex: 1,
@@ -152,13 +122,13 @@ const styles = StyleSheet.create({
   trendBarLabel: {
     width: 26,
     fontSize: 7.5,
-    color: "#6c727a",
+    color: color.muted,
     textTransform: "uppercase",
   },
   trendBarTrack: {
     flex: 1,
     height: 6,
-    backgroundColor: "#f3eee5",
+    backgroundColor: color.panel,
     borderRadius: 3,
   },
   trendBarFill: {
@@ -168,24 +138,10 @@ const styles = StyleSheet.create({
   trendNet: {
     width: 80,
     textAlign: "right",
-    fontSize: 9,
+    fontSize: size.micro,
   },
-  emptyNote: {
-    fontSize: 10,
-    color: "#9a9c9f",
-  },
-  footer: {
-    position: "absolute",
-    bottom: 32,
-    left: 56,
-    right: 56,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    fontSize: 8,
-    color: "#9a9c9f",
-    letterSpacing: 0.6,
-  },
-  pageNum: { fontFamily: "Courier" },
+
+  empty: { fontSize: size.small, color: color.faint },
 });
 
 export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
@@ -205,14 +161,24 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
       author={props.buildingName}
     >
       <Page size="A4" style={styles.page}>
-        <Text style={styles.eyebrow}>Pénzügyi összesítő</Text>
+        <ReportHeader reportType="Pénzügyi összefoglaló" />
+
+        {/* Title block */}
         <Text style={styles.title}>{props.period.label}</Text>
-        <Text style={styles.subtitle}>{props.buildingName}</Text>
+        <Text style={styles.buildingLine}>{props.buildingName}</Text>
         <Text style={styles.meta}>
           Időszak: {props.period.label} · forgalom havi bontásban
         </Text>
 
+        {/* Net result status */}
+        <StatusPill tone={props.netChange >= 0 ? "positive" : "negative"}>
+          {props.netChange >= 0
+            ? `Pénzügyi többlet · ${formatHUF(props.netChange)}`
+            : `Pénzügyi hiány · ${formatHUF(props.netChange)}`}
+        </StatusPill>
+
         {/* KPI ROW */}
+        <SectionTitle>Egyenlegek</SectionTitle>
         <View style={styles.kpiRow}>
           <View style={styles.kpiCell}>
             <Text style={styles.kpiLabel}>Nyitóegyenleg</Text>
@@ -243,20 +209,20 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
         </View>
 
         {/* INCOME */}
-        <Text style={styles.sectionHeader}>Bevételek kategóriánként</Text>
+        <SectionTitle>Bevételek kategóriánként</SectionTitle>
         {props.incomeByCategory.length === 0 ? (
-          <Text style={styles.emptyNote}>Nincs bevétel a megadott időszakban.</Text>
+          <Text style={styles.empty}>Nincs bevétel a megadott időszakban.</Text>
         ) : (
           <View>
-            <View style={styles.rowHeader}>
+            <View style={styles.thRow}>
               <Text style={styles.category}>Kategória</Text>
               <Text style={styles.amount}>Összeg</Text>
               <Text style={styles.share}>Arány</Text>
             </View>
-            {props.incomeByCategory.map((c) => {
+            {props.incomeByCategory.map((c, i) => {
               const pct = props.totalIncome > 0 ? (c.amount / props.totalIncome) * 100 : 0;
               return (
-                <View key={c.category} style={styles.row}>
+                <View key={c.category} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]}>
                   <Text style={styles.category}>{c.category}</Text>
                   <Text style={[styles.amount, styles.good]}>
                     {formatHUF(c.amount)}
@@ -269,20 +235,20 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
         )}
 
         {/* EXPENSE */}
-        <Text style={styles.sectionHeader}>Kiadások kategóriánként</Text>
+        <SectionTitle>Kiadások kategóriánként</SectionTitle>
         {props.expenseByCategory.length === 0 ? (
-          <Text style={styles.emptyNote}>Nincs kiadás a megadott időszakban.</Text>
+          <Text style={styles.empty}>Nincs kiadás a megadott időszakban.</Text>
         ) : (
           <View>
-            <View style={styles.rowHeader}>
+            <View style={styles.thRow}>
               <Text style={styles.category}>Kategória</Text>
               <Text style={styles.amount}>Összeg</Text>
               <Text style={styles.share}>Arány</Text>
             </View>
-            {props.expenseByCategory.map((c) => {
+            {props.expenseByCategory.map((c, i) => {
               const pct = props.totalExpenses > 0 ? (c.amount / props.totalExpenses) * 100 : 0;
               return (
-                <View key={c.category} style={styles.row}>
+                <View key={c.category} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]}>
                   <Text style={styles.category}>{c.category}</Text>
                   <Text style={[styles.amount, styles.bad]}>
                     {formatHUF(c.amount)}
@@ -295,21 +261,21 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
         )}
 
         {/* TOP ENTRIES */}
-        <Text style={styles.sectionHeader}>
+        <SectionTitle>
           10 legnagyobb tétel · {formatNumber(props.topEntries.length)} db
-        </Text>
+        </SectionTitle>
         {props.topEntries.length === 0 ? (
-          <Text style={styles.emptyNote}>Nincs könyvelt tétel az időszakban.</Text>
+          <Text style={styles.empty}>Nincs könyvelt tétel az időszakban.</Text>
         ) : (
           <View>
-            <View style={styles.rowHeader}>
+            <View style={styles.thRow}>
               <Text style={styles.topDate}>Dátum</Text>
               <Text style={styles.topDesc}>Megnevezés</Text>
               <Text style={styles.topCategory}>Kategória</Text>
               <Text style={styles.topAmount}>Összeg</Text>
             </View>
-            {props.topEntries.map((e) => (
-              <View key={e.id} style={styles.topRow} wrap={false}>
+            {props.topEntries.map((e, i) => (
+              <View key={e.id} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]} wrap={false}>
                 <Text style={styles.topDate}>
                   {new Date(e.date).toLocaleDateString("hu-HU")}
                 </Text>
@@ -330,9 +296,9 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
         )}
 
         {/* MONTHLY TREND */}
-        <Text style={styles.sectionHeader}>Havi trend · 6 hónap</Text>
+        <SectionTitle>Havi trend · 6 hónap</SectionTitle>
         {props.monthlyTrend.length === 0 ? (
-          <Text style={styles.emptyNote}>Nincs adat a megelőző hónapokra.</Text>
+          <Text style={styles.empty}>Nincs adat a megelőző hónapokra.</Text>
         ) : (
           <View>
             {props.monthlyTrend.map((t) => {
@@ -348,7 +314,7 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
                         <View
                           style={[
                             styles.trendBarFill,
-                            { width: `${incomePct}%`, backgroundColor: "#4a5a3e" },
+                            { width: `${incomePct}%`, backgroundColor: color.positive },
                           ]}
                         />
                       </View>
@@ -359,7 +325,7 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
                         <View
                           style={[
                             styles.trendBarFill,
-                            { width: `${expensePct}%`, backgroundColor: "#a04040" },
+                            { width: `${expensePct}%`, backgroundColor: color.negative },
                           ]}
                         />
                       </View>
@@ -379,18 +345,11 @@ export function FinanceSummaryPdf(props: FinanceSummaryPdfProps) {
           </View>
         )}
 
-        <View style={styles.footer} fixed>
-          <Text>
-            {props.buildingName} · {formatDateTime(props.generatedAt)} · hash{" "}
-            {shortHash(props.contentHash)}
-          </Text>
-          <Text
-            style={styles.pageNum}
-            render={({ pageNumber, totalPages }) =>
-              `${pageNumber} / ${totalPages}`
-            }
-          />
-        </View>
+        <ReportFooter
+          buildingName={props.buildingName}
+          generatedAt={props.generatedAt}
+          contentHash={props.contentHash}
+        />
       </Page>
     </Document>
   );

--- a/src/reports/templates/meeting-summary.tsx
+++ b/src/reports/templates/meeting-summary.tsx
@@ -1,18 +1,8 @@
 import * as React from "react";
-import {
-  Document,
-  Page,
-  Text,
-  View,
-  StyleSheet,
-} from "@react-pdf/renderer";
-import {
-  formatDate,
-  formatDateTime,
-  formatPercent,
-  formatNumber,
-} from "../lib/format";
-import { shortHash } from "../lib/footer";
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+import { formatDate, formatPercent, formatNumber } from "../lib/format";
+import { color, font, size, space, majorityLabel } from "../lib/theme";
+import { ReportHeader, ReportFooter, SectionTitle, StatusPill } from "../lib/components";
 
 export interface MeetingSummaryPdfProps {
   buildingName: string;
@@ -54,199 +44,108 @@ export interface MeetingSummaryPdfProps {
 
 const styles = StyleSheet.create({
   page: {
-    padding: "48 56 64 56",
-    fontSize: 10.5,
-    color: "#16181a",
-    fontFamily: "Manrope",
-    lineHeight: 1.4,
+    paddingTop: space.pageTop,
+    paddingBottom: space.pageBottom,
+    paddingHorizontal: space.pageX,
+    fontSize: size.body,
+    color: color.ink,
+    fontFamily: font.sans,
+    lineHeight: 1.45,
   },
-  eyebrow: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 500,
-    letterSpacing: -0.5,
-    lineHeight: 1.25,
-    marginBottom: 8,
-    color: "#16181a",
-  },
-  buildingLine: {
-    fontSize: 11,
-    color: "#3a4048",
-    marginBottom: 4,
-  },
-  metaLine: {
-    fontSize: 10,
-    color: "#3a4048",
-    marginBottom: 24,
-  },
-  description: {
-    fontSize: 10.5,
-    lineHeight: 1.55,
-    marginBottom: 20,
-    color: "#3a4048",
-  },
-  sectionHeader: {
-    fontSize: 11,
-    color: "#16181a",
-    fontWeight: 700,
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-    marginBottom: 10,
-    marginTop: 16,
-    paddingBottom: 4,
-    borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
-    borderBottomStyle: "solid",
-  },
-  agendaItem: {
-    flexDirection: "row",
-    marginBottom: 8,
-    gap: 10,
-  },
+
+  // Title block
+  title: { fontSize: size.title, fontWeight: 700, letterSpacing: -0.5, lineHeight: 1.2, marginBottom: 6 },
+  buildingLine: { fontSize: size.lead, fontWeight: 500, color: color.inkSoft, marginBottom: 3 },
+  meta: { fontSize: size.small, color: color.muted, marginBottom: 14 },
+  description: { fontSize: size.body, lineHeight: 1.55, marginBottom: 8, color: color.inkSoft },
+
+  // Agenda
+  agendaItem: { flexDirection: "row", marginBottom: 7 },
   agendaIndex: {
-    width: 18,
-    fontWeight: 500,
-    color: "#6c727a",
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: color.panel,
+    color: color.ochre,
+    fontSize: size.micro,
+    fontWeight: 700,
+    textAlign: "center",
+    lineHeight: 1.55,
+    marginRight: 9,
   },
-  agendaBody: {
-    flex: 1,
+  agendaTitle: { fontWeight: 500 },
+  agendaDesc: { fontSize: size.small, color: color.muted, marginTop: 1 },
+
+  // Vote card
+  card: {
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: color.panelEdge,
+    borderStyle: "solid",
+    borderRadius: 8,
+    overflow: "hidden",
   },
-  agendaTitle: {
-    fontWeight: 500,
-    color: "#16181a",
-  },
-  agendaDesc: {
-    fontSize: 9.5,
-    color: "#6c727a",
-    marginTop: 1,
-  },
-  voteBlock: {
-    marginBottom: 14,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 6,
-    padding: 12,
-  },
-  voteHeader: {
+  cardHead: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 6,
+    backgroundColor: color.panel,
+    paddingVertical: 7,
+    paddingHorizontal: 12,
   },
-  voteTitle: {
-    fontSize: 12,
-    fontWeight: 500,
-    color: "#16181a",
-    flex: 1,
-  },
-  badge: {
-    fontSize: 8,
-    fontWeight: 700,
-    paddingTop: 2,
-    paddingBottom: 2,
-    paddingLeft: 6,
-    paddingRight: 6,
-    borderRadius: 10,
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-  },
-  badgePassed: { backgroundColor: "#e0eee0", color: "#4a5a3e" },
-  badgeRejected: { backgroundColor: "#f4dada", color: "#a04040" },
-  badgePending: { backgroundColor: "#e8e6e1", color: "#6c727a" },
-  voteMeta: {
-    fontSize: 9,
-    color: "#6c727a",
-    marginBottom: 8,
-  },
-  optionRow: {
+  voteTitle: { fontSize: 12, fontWeight: 700, flex: 1, marginRight: 10 },
+  cardBody: { paddingHorizontal: 12, paddingVertical: 10 },
+  voteMeta: { fontSize: size.micro, color: color.muted, marginBottom: 7 },
+
+  // Options table
+  thRow: {
     flexDirection: "row",
-    paddingTop: 4,
-    paddingBottom: 4,
-    borderBottomWidth: 0.5,
-    borderBottomColor: "#e8e6e1",
-    borderBottomStyle: "solid",
-  },
-  optionRowHeader: {
-    flexDirection: "row",
-    paddingBottom: 4,
-    fontSize: 8,
-    color: "#6c727a",
-    letterSpacing: 1,
-    textTransform: "uppercase",
+    paddingBottom: 5,
     borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
+    borderBottomColor: color.lineStrong,
     borderBottomStyle: "solid",
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
     marginBottom: 2,
   },
-  optionLabel: { flex: 3 },
-  optionBallots: { flex: 1, textAlign: "right" },
-  optionShare: { flex: 1, textAlign: "right" },
-  optionPercent: { flex: 1, textAlign: "right", fontWeight: 500 },
+  tr: {
+    flexDirection: "row",
+    paddingVertical: 4.5,
+    borderBottomWidth: 0.5,
+    borderBottomColor: color.line,
+    borderBottomStyle: "solid",
+    fontSize: size.small,
+  },
+  trZebra: { backgroundColor: color.panel },
+  optLabel: { flex: 3 },
+  optVotes: { flex: 1, textAlign: "right" },
+  optShare: { flex: 1, textAlign: "right" },
+  optPercent: { flex: 1, textAlign: "right", fontWeight: 500 },
+
+  // Pending items
   pendingItem: {
     marginBottom: 10,
     paddingLeft: 10,
     borderLeftWidth: 2,
-    borderLeftColor: "#c89858",
+    borderLeftColor: color.ochre,
     borderLeftStyle: "solid",
   },
   pendingKind: {
-    fontSize: 8,
-    color: "#6c727a",
-    letterSpacing: 1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
     marginBottom: 2,
   },
-  pendingTitle: {
-    fontSize: 11,
-    fontWeight: 500,
-    color: "#16181a",
-  },
-  pendingDesc: {
-    fontSize: 9.5,
-    color: "#3a4048",
-    marginTop: 2,
-  },
-  resolutionNote: {
-    fontSize: 9,
-    color: "#4a5a3e",
-    marginTop: 4,
-  },
-  minutesBlock: {
-    fontSize: 10,
-    color: "#3a4048",
-    lineHeight: 1.6,
-    marginTop: 6,
-  },
-  emptyNote: {
-    fontSize: 10,
-    color: "#9a9c9f",
-  },
-  footer: {
-    position: "absolute",
-    bottom: 32,
-    left: 56,
-    right: 56,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    fontSize: 8,
-    color: "#9a9c9f",
-    letterSpacing: 0.6,
-  },
-  pageNum: {
-    fontFamily: "Courier",
-  },
-});
+  pendingTitle: { fontSize: 11, fontWeight: 500 },
+  pendingDesc: { fontSize: size.small, color: color.inkSoft, marginTop: 2 },
+  resolutionNote: { fontSize: size.micro, color: color.positive, marginTop: 4 },
 
-const MAJORITY_LABEL: Record<string, string> = {
-  SIMPLE_MAJORITY: "egyszerű többség",
-  TWO_THIRDS: "kétharmados",
-  UNANIMOUS: "egyhangú",
-};
+  minutesBlock: { fontSize: size.body, lineHeight: 1.6, color: color.inkSoft, marginTop: 6 },
+  empty: { fontSize: size.small, color: color.faint },
+});
 
 const PENDING_KIND_LABEL: Record<string, string> = {
   COMPLAINT_ESCALATION: "Eszkalált panasz",
@@ -255,60 +154,50 @@ const PENDING_KIND_LABEL: Record<string, string> = {
 
 function VoteBlock({ vote }: { vote: MeetingSummaryPdfProps["votes"][number] }) {
   const isClosed = vote.status === "CLOSED";
-  const badgeStyle =
-    !isClosed
-      ? styles.badgePending
-      : vote.passed === true
-        ? styles.badgePassed
-        : styles.badgeRejected;
-  const badgeText =
-    !isClosed
-      ? "Folyamatban"
-      : vote.passed === true
-        ? "Elfogadva"
-        : "Elutasítva";
+  const tone = !isClosed ? "neutral" : vote.passed === true ? "positive" : "negative";
+  const badgeText = !isClosed ? "Folyamatban" : vote.passed === true ? "Elfogadva" : "Elutasítva";
 
   const turnoutPct = vote.totalEligibleWeight
     ? (vote.totalCastWeight / vote.totalEligibleWeight) * 100
     : 0;
 
   return (
-    <View style={styles.voteBlock} wrap={false}>
-      <View style={styles.voteHeader}>
+    <View style={styles.card} wrap={false}>
+      <View style={styles.cardHead}>
         <Text style={styles.voteTitle}>{vote.title}</Text>
-        <Text style={[styles.badge, badgeStyle]}>{badgeText}</Text>
+        <StatusPill tone={tone}>{badgeText}</StatusPill>
       </View>
-      <Text style={styles.voteMeta}>
-        {MAJORITY_LABEL[vote.majorityType] ?? vote.majorityType}
-        {" · részvétel "}
-        {formatPercent(turnoutPct)}
-        {" · "}
-        {formatNumber(vote.ballotCount)} szavazó
-        {vote.isSecret ? " · titkos" : ""}
-        {" · határidő "}
-        {formatDate(vote.deadline)}
-      </Text>
+      <View style={styles.cardBody}>
+        <Text style={styles.voteMeta}>
+          {majorityLabel(vote.majorityType)}
+          {" · részvétel "}
+          {formatPercent(turnoutPct)}
+          {" · "}
+          {formatNumber(vote.ballotCount)} szavazó
+          {vote.isSecret ? " · titkos" : ""}
+          {" · határidő "}
+          {formatDate(vote.deadline)}
+        </Text>
 
-      <View style={styles.optionRowHeader}>
-        <Text style={styles.optionLabel}>Opció</Text>
-        <Text style={styles.optionBallots}>Szavazat</Text>
-        <Text style={styles.optionShare}>Hányad</Text>
-        <Text style={styles.optionPercent}>Arány</Text>
+        <View style={styles.thRow}>
+          <Text style={styles.optLabel}>Opció</Text>
+          <Text style={styles.optVotes}>Szavazat</Text>
+          <Text style={styles.optShare}>Hányad</Text>
+          <Text style={styles.optPercent}>Arány</Text>
+        </View>
+        {vote.options.map((o, i) => {
+          const pctOfCast =
+            vote.totalCastWeight > 0 ? (o.weight / vote.totalCastWeight) * 100 : 0;
+          return (
+            <View key={o.id} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]}>
+              <Text style={styles.optLabel}>{o.label}</Text>
+              <Text style={styles.optVotes}>{formatNumber(o.ballotCount)}</Text>
+              <Text style={styles.optShare}>{formatPercent(o.weight * 100)}</Text>
+              <Text style={styles.optPercent}>{formatPercent(pctOfCast)}</Text>
+            </View>
+          );
+        })}
       </View>
-      {vote.options.map((o) => {
-        const pctOfCast =
-          vote.totalCastWeight > 0
-            ? (o.weight / vote.totalCastWeight) * 100
-            : 0;
-        return (
-          <View key={o.id} style={styles.optionRow}>
-            <Text style={styles.optionLabel}>{o.label}</Text>
-            <Text style={styles.optionBallots}>{formatNumber(o.ballotCount)}</Text>
-            <Text style={styles.optionShare}>{formatPercent(o.weight * 100)}</Text>
-            <Text style={styles.optionPercent}>{formatPercent(pctOfCast)}</Text>
-          </View>
-        );
-      })}
     </View>
   );
 }
@@ -320,10 +209,12 @@ export function MeetingSummaryPdf(props: MeetingSummaryPdfProps) {
       author={props.buildingName}
     >
       <Page size="A4" style={styles.page}>
-        <Text style={styles.eyebrow}>Közgyűlés összegzés</Text>
+        <ReportHeader reportType="Közgyűlési összefoglaló" />
+
+        {/* Title block */}
         <Text style={styles.title}>{props.meeting.title}</Text>
         <Text style={styles.buildingLine}>{props.buildingName}</Text>
-        <Text style={styles.metaLine}>
+        <Text style={styles.meta}>
           {formatDate(props.meeting.date)} · {props.meeting.time}
           {props.meeting.location ? ` · ${props.meeting.location}` : ""}
         </Text>
@@ -332,14 +223,15 @@ export function MeetingSummaryPdf(props: MeetingSummaryPdfProps) {
           <Text style={styles.description}>{props.meeting.description}</Text>
         )}
 
-        <Text style={styles.sectionHeader}>Napirend</Text>
+        {/* AGENDA */}
+        <SectionTitle>Napirend</SectionTitle>
         {props.agenda.length === 0 ? (
-          <Text style={styles.emptyNote}>Nincs rögzített napirend.</Text>
+          <Text style={styles.empty}>Nincs rögzített napirend.</Text>
         ) : (
           props.agenda.map((item, i) => (
             <View key={i} style={styles.agendaItem} wrap={false}>
-              <Text style={styles.agendaIndex}>{i + 1}.</Text>
-              <View style={styles.agendaBody}>
+              <Text style={styles.agendaIndex}>{i + 1}</Text>
+              <View style={{ flex: 1 }}>
                 <Text style={styles.agendaTitle}>{item.title}</Text>
                 {item.description && (
                   <Text style={styles.agendaDesc}>{item.description}</Text>
@@ -349,16 +241,18 @@ export function MeetingSummaryPdf(props: MeetingSummaryPdfProps) {
           ))
         )}
 
-        <Text style={styles.sectionHeader}>Szavazások</Text>
+        {/* VOTES */}
+        <SectionTitle>Szavazások</SectionTitle>
         {props.votes.length === 0 ? (
-          <Text style={styles.emptyNote}>Nincs szavazás a közgyűléshez kötve.</Text>
+          <Text style={styles.empty}>Nincs szavazás a közgyűléshez kötve.</Text>
         ) : (
           props.votes.map((v) => <VoteBlock key={v.id} vote={v} />)
         )}
 
+        {/* PENDING ITEMS */}
         {props.pendingItems.length > 0 && (
           <>
-            <Text style={styles.sectionHeader}>Függőben lévő ügyek</Text>
+            <SectionTitle>Függőben lévő ügyek</SectionTitle>
             {props.pendingItems.map((p) => (
               <View key={p.id} style={styles.pendingItem} wrap={false}>
                 <Text style={styles.pendingKind}>
@@ -379,25 +273,19 @@ export function MeetingSummaryPdf(props: MeetingSummaryPdfProps) {
           </>
         )}
 
+        {/* MINUTES */}
         {props.meeting.minutes && (
           <>
-            <Text style={styles.sectionHeader}>Jegyzőkönyv</Text>
+            <SectionTitle>Jegyzőkönyv</SectionTitle>
             <Text style={styles.minutesBlock}>{props.meeting.minutes}</Text>
           </>
         )}
 
-        <View style={styles.footer} fixed>
-          <Text>
-            {props.buildingName} · {formatDateTime(props.generatedAt)} · hash{" "}
-            {shortHash(props.contentHash)}
-          </Text>
-          <Text
-            style={styles.pageNum}
-            render={({ pageNumber, totalPages }) =>
-              `${pageNumber} / ${totalPages}`
-            }
-          />
-        </View>
+        <ReportFooter
+          buildingName={props.buildingName}
+          generatedAt={props.generatedAt}
+          contentHash={props.contentHash}
+        />
       </Page>
     </Document>
   );

--- a/src/reports/templates/minutes.tsx
+++ b/src/reports/templates/minutes.tsx
@@ -1,18 +1,8 @@
 import * as React from "react";
-import {
-  Document,
-  Page,
-  Text,
-  View,
-  StyleSheet,
-} from "@react-pdf/renderer";
-import {
-  formatDate,
-  formatDateTime,
-  formatPercent,
-  formatNumber,
-} from "../lib/format";
-import { shortHash } from "../lib/footer";
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+import { formatDate, formatPercent, formatNumber } from "../lib/format";
+import { color, font, size, space, majorityLabel } from "../lib/theme";
+import { ReportHeader, ReportFooter, SectionTitle, StatusPill } from "../lib/components";
 import type { MinutesData } from "@/lib/reports/minutes-data";
 
 export interface MinutesPdfProps extends MinutesData {
@@ -22,193 +12,109 @@ export interface MinutesPdfProps extends MinutesData {
 
 const styles = StyleSheet.create({
   page: {
-    padding: "48 56 64 56",
-    fontSize: 10.5,
-    color: "#16181a",
-    fontFamily: "Manrope",
+    paddingTop: space.pageTop,
+    paddingBottom: space.pageBottom,
+    paddingHorizontal: space.pageX,
+    fontSize: size.body,
+    color: color.ink,
+    fontFamily: font.sans,
     lineHeight: 1.45,
   },
-  eyebrow: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 500,
-    letterSpacing: -0.5,
-    lineHeight: 1.25,
-    marginBottom: 6,
-  },
-  buildingLine: {
-    fontSize: 11,
-    color: "#3a4048",
-    marginBottom: 4,
-  },
-  meta: { fontSize: 10, color: "#3a4048", marginBottom: 14 },
-  draftBanner: {
-    fontSize: 9,
-    color: "#a04040",
-    backgroundColor: "color-mix(in srgb, #a04040 14%, transparent)",
-    padding: 8,
-    borderRadius: 5,
-    marginBottom: 18,
-    borderLeftWidth: 3,
-    borderLeftColor: "#a04040",
-  },
-  executedBanner: {
-    fontSize: 9,
-    color: "#4a5a3e",
-    backgroundColor: "color-mix(in srgb, #4a5a3e 14%, transparent)",
-    padding: 8,
-    borderRadius: 5,
-    marginBottom: 18,
-    borderLeftWidth: 3,
-    borderLeftColor: "#4a5a3e",
-  },
-  sectionHeader: {
-    fontSize: 11,
+
+  // Title block
+  title: { fontSize: size.title, fontWeight: 700, letterSpacing: -0.5, lineHeight: 1.2, marginBottom: 6 },
+  buildingLine: { fontSize: size.lead, fontWeight: 500, color: color.inkSoft, marginBottom: 3 },
+  meta: { fontSize: size.small, color: color.muted, marginBottom: 14 },
+
+  // Agenda
+  agendaItem: { flexDirection: "row", marginBottom: 7 },
+  agendaIndex: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: color.panel,
+    color: color.ochre,
+    fontSize: size.micro,
     fontWeight: 700,
-    color: "#16181a",
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-    marginTop: 16,
-    marginBottom: 10,
-    paddingBottom: 4,
-    borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
-    borderBottomStyle: "solid",
+    textAlign: "center",
+    lineHeight: 1.55,
+    marginRight: 9,
   },
-  miniHeader: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.1,
-    textTransform: "uppercase",
-    marginBottom: 4,
-  },
-  agendaItem: {
-    flexDirection: "row",
-    marginBottom: 8,
-    gap: 10,
-  },
-  agendaIndex: { width: 18, color: "#6c727a", fontWeight: 500 },
   agendaTitle: { fontWeight: 500 },
-  agendaDesc: { fontSize: 9.5, color: "#6c727a", marginTop: 1 },
-  attendRowHeader: {
+  agendaDesc: { fontSize: size.small, color: color.muted, marginTop: 1 },
+
+  // Tables (attendance + options share the look)
+  thRow: {
     flexDirection: "row",
     paddingBottom: 5,
     borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
+    borderBottomColor: color.lineStrong,
     borderBottomStyle: "solid",
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
   },
-  attendRow: {
+  tr: {
     flexDirection: "row",
-    paddingTop: 5,
-    paddingBottom: 5,
+    paddingVertical: 4.5,
     borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
+    borderBottomColor: color.line,
     borderBottomStyle: "solid",
-    fontSize: 9.5,
+    fontSize: size.small,
   },
-  attendUnit: { width: 50 },
-  attendOwner: { flex: 2 },
-  attendShare: { width: 70, textAlign: "right", color: "#6c727a" },
-  attendCheckin: { width: 80, textAlign: "right", color: "#6c727a", fontSize: 9 },
-  attendTotalRow: {
-    flexDirection: "row",
-    paddingTop: 6,
-    borderTopWidth: 1,
-    borderTopColor: "#16181a",
-    marginTop: 4,
+  trZebra: { backgroundColor: color.panel },
+  attUnit: { width: 52 },
+  attOwner: { flex: 2 },
+  attShare: { width: 70, textAlign: "right", color: color.muted },
+  attCheck: { width: 70, textAlign: "right", color: color.muted, fontSize: size.micro },
+  totalRow: { flexDirection: "row", paddingTop: 6, borderTopWidth: 1, borderTopColor: color.lineStrong, marginTop: 2 },
+  quorumNote: { marginTop: 10 },
+
+  // Resolution card
+  card: {
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: color.panelEdge,
+    borderStyle: "solid",
+    borderRadius: 8,
+    overflow: "hidden",
   },
-  resolutionBox: {
-    marginBottom: 14,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 6,
-    padding: 12,
-  },
-  resolutionTitle: {
-    fontSize: 12,
-    fontWeight: 500,
-    marginBottom: 4,
-  },
-  resolutionDesc: {
-    fontSize: 10,
-    color: "#3a4048",
-    marginBottom: 6,
-    lineHeight: 1.5,
-  },
-  resolutionMeta: {
-    fontSize: 9,
-    color: "#6c727a",
-    marginBottom: 6,
-  },
-  optionRow: {
-    flexDirection: "row",
-    paddingTop: 3,
-    paddingBottom: 3,
-  },
-  optionLabel: { flex: 3 },
-  optionVotes: { flex: 1, textAlign: "right" },
-  optionWeight: { flex: 1, textAlign: "right" },
-  optionShare: { flex: 1, textAlign: "right", color: "#6c727a" },
-  resolutionFooter: {
-    marginTop: 8,
-    paddingTop: 6,
-    borderTopWidth: 0.5,
-    borderTopColor: "#d4d2cc",
-    fontSize: 9.5,
-  },
-  passed: { color: "#4a5a3e", fontWeight: 500 },
-  rejected: { color: "#a04040", fontWeight: 500 },
-  pending: { color: "#6c727a" },
-  signatureGrid: {
-    flexDirection: "row",
-    gap: 10,
-    marginTop: 6,
-  },
-  signatureCell: {
-    flex: 1,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 6,
-    padding: 12,
-    minHeight: 90,
-  },
-  sigRoleLabel: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.1,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  sigName: { fontSize: 11, fontWeight: 500, marginBottom: 4 },
-  sigDate: { fontSize: 9, color: "#6c727a" },
-  sigPlaceholder: { fontSize: 10, color: "#9a9c9f" },
-  sigLine: {
-    marginTop: 28,
-    borderTopWidth: 0.5,
-    borderTopColor: "#16181a",
-    borderTopStyle: "solid",
-  },
-  emptyNote: { fontSize: 10, color: "#9a9c9f" },
-  footer: {
-    position: "absolute",
-    bottom: 32,
-    left: 56,
-    right: 56,
+  cardHead: {
     flexDirection: "row",
     justifyContent: "space-between",
-    fontSize: 8,
-    color: "#9a9c9f",
-    letterSpacing: 0.6,
+    alignItems: "center",
+    backgroundColor: color.panel,
+    paddingVertical: 7,
+    paddingHorizontal: 12,
   },
-  pageNum: { fontFamily: "Courier" },
+  cardKicker: { fontSize: size.micro, fontWeight: 700, letterSpacing: 0.8, textTransform: "uppercase", color: color.muted },
+  cardBody: { paddingHorizontal: 12, paddingVertical: 10 },
+  resTitle: { fontSize: 12, fontWeight: 700, marginBottom: 3 },
+  resDesc: { fontSize: size.small, color: color.inkSoft, marginBottom: 7, lineHeight: 1.5 },
+  resMeta: { fontSize: size.micro, color: color.muted, marginBottom: 7 },
+  optRow: { flexDirection: "row", paddingVertical: 2.5 },
+  optLabel: { flex: 3 },
+  optVotes: { flex: 1, textAlign: "right" },
+  optWeight: { flex: 1, textAlign: "right" },
+  optShare: { flex: 1, textAlign: "right", color: color.muted },
+  resFooter: { marginTop: 8, paddingTop: 7, borderTopWidth: 0.5, borderTopColor: color.line, fontSize: size.small },
+
+  passed: { color: color.positive, fontWeight: 700 },
+  rejected: { color: color.negative, fontWeight: 700 },
+  pending: { color: color.muted },
+
+  // Signatures
+  sigGrid: { flexDirection: "row", gap: 10, marginTop: 4 },
+  sigCell: { flex: 1, borderWidth: 1, borderColor: color.panelEdge, borderStyle: "solid", borderRadius: 8, padding: 12, minHeight: 92 },
+  sigRole: { fontSize: size.micro, color: color.muted, letterSpacing: 0.9, textTransform: "uppercase", marginBottom: 8 },
+  sigName: { fontSize: 11, fontWeight: 700, marginBottom: 3 },
+  sigDate: { fontSize: size.micro, color: color.muted },
+  sigPlaceholder: { fontSize: size.small, color: color.faint },
+  sigLine: { marginTop: 26, borderTopWidth: 0.5, borderTopColor: color.ink, borderTopStyle: "solid" },
+
+  empty: { fontSize: size.small, color: color.faint },
+  prose: { fontSize: size.body, lineHeight: 1.6, color: color.inkSoft },
 });
 
 const ROLE_LABEL: Record<string, string> = {
@@ -218,13 +124,14 @@ const ROLE_LABEL: Record<string, string> = {
 };
 
 export function MinutesPdf(props: MinutesPdfProps) {
+  const signedCount = props.signatures.filter((sig) => sig.signerName).length;
+
   return (
-    <Document
-      title={`Jegyzőkönyv — ${props.meeting.title}`}
-      author={props.buildingName}
-    >
+    <Document title={`Jegyzőkönyv — ${props.meeting.title}`} author={props.buildingName}>
       <Page size="A4" style={styles.page}>
-        <Text style={styles.eyebrow}>Közgyűlési jegyzőkönyv · Tht. § 39</Text>
+        <ReportHeader reportType="Közgyűlési jegyzőkönyv" reportRef="Tht. § 39" />
+
+        {/* Title block */}
         <Text style={styles.title}>{props.meeting.title}</Text>
         <Text style={styles.buildingLine}>{props.buildingName}</Text>
         <Text style={styles.meta}>
@@ -234,208 +141,162 @@ export function MinutesPdf(props: MinutesPdfProps) {
         </Text>
 
         {props.isExecuted ? (
-          <Text style={styles.executedBanner}>
-            Hitelesítve · mindhárom aláírás rögzítve. A jegyzőkönyv jogi
-            erővel bír.
-          </Text>
+          <StatusPill tone="positive">Hitelesítve · mindhárom aláírás rögzítve</StatusPill>
         ) : (
-          <Text style={styles.draftBanner}>
-            Tervezet · {props.signatures.filter((s) => s.signerName).length}/3
-            aláírás rögzítve. A jegyzőkönyv csak a három aláírással válik
-            hitelessé.
-          </Text>
+          <StatusPill tone="warning">{`Tervezet · ${signedCount}/3 aláírás — a három aláírással válik hitelessé`}</StatusPill>
         )}
 
         {/* AGENDA */}
-        <Text style={styles.sectionHeader}>Napirend</Text>
+        <SectionTitle>Napirend</SectionTitle>
         {props.agenda.length === 0 ? (
-          <Text style={styles.emptyNote}>Nincs rögzített napirend.</Text>
+          <Text style={styles.empty}>Nincs rögzített napirend.</Text>
         ) : (
           props.agenda.map((item, i) => (
             <View key={i} style={styles.agendaItem} wrap={false}>
-              <Text style={styles.agendaIndex}>{i + 1}.</Text>
+              <Text style={styles.agendaIndex}>{i + 1}</Text>
               <View style={{ flex: 1 }}>
                 <Text style={styles.agendaTitle}>{item.title}</Text>
-                {item.description && (
-                  <Text style={styles.agendaDesc}>{item.description}</Text>
-                )}
+                {item.description ? <Text style={styles.agendaDesc}>{item.description}</Text> : null}
               </View>
             </View>
           ))
         )}
 
         {/* ATTENDANCE */}
-        <Text style={styles.sectionHeader}>Jelenléti ív · határozatképesség</Text>
+        <SectionTitle>Jelenléti ív · határozatképesség</SectionTitle>
         {props.attendance.length === 0 ? (
-          <Text style={styles.emptyNote}>
-            Nincs rögzített megjelent tulajdonos.
-          </Text>
+          <Text style={styles.empty}>Nincs rögzített megjelent tulajdonos.</Text>
         ) : (
           <View>
-            <View style={styles.attendRowHeader}>
-              <Text style={styles.attendUnit}>Albetét</Text>
-              <Text style={styles.attendOwner}>Tulajdonos</Text>
-              <Text style={styles.attendShare}>Hányad</Text>
-              <Text style={styles.attendCheckin}>Érkeztetés</Text>
+            <View style={styles.thRow}>
+              <Text style={styles.attUnit}>Albetét</Text>
+              <Text style={styles.attOwner}>Tulajdonos</Text>
+              <Text style={styles.attShare}>Hányad</Text>
+              <Text style={styles.attCheck}>Érkeztetés</Text>
             </View>
-            {props.attendance.map((a) => (
-              <View key={a.unitNumber} style={styles.attendRow} wrap={false}>
-                <Text style={styles.attendUnit}>#{a.unitNumber}</Text>
-                <Text style={styles.attendOwner}>{a.ownerName}</Text>
-                <Text style={styles.attendShare}>
-                  {(a.ownershipShare * 100).toFixed(2)}%
-                </Text>
-                <Text style={styles.attendCheckin}>
-                  {new Date(a.checkedInAt).toLocaleTimeString("hu-HU", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
+            {props.attendance.map((a, i) => (
+              <View key={a.unitNumber} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]} wrap={false}>
+                <Text style={styles.attUnit}>#{a.unitNumber}</Text>
+                <Text style={styles.attOwner}>{a.ownerName}</Text>
+                <Text style={styles.attShare}>{(a.ownershipShare * 100).toFixed(2)}%</Text>
+                <Text style={styles.attCheck}>
+                  {new Date(a.checkedInAt).toLocaleTimeString("hu-HU", { hour: "2-digit", minute: "2-digit" })}
                 </Text>
               </View>
             ))}
-            <View style={styles.attendTotalRow}>
-              <Text style={styles.attendUnit} />
-              <Text style={[styles.attendOwner, { fontWeight: 500 }]}>
+            <View style={styles.totalRow}>
+              <Text style={styles.attUnit} />
+              <Text style={[styles.attOwner, { fontWeight: 700 }]}>
                 Megjelent · {formatNumber(props.attendance.length)} albetét
               </Text>
-              <Text
-                style={[
-                  styles.attendShare,
-                  { color: "#16181a", fontWeight: 500 },
-                ]}
-              >
+              <Text style={[styles.attShare, { color: color.ink, fontWeight: 700 }]}>
                 {formatPercent(props.totalAttendingShare * 100)}
               </Text>
-              <Text style={styles.attendCheckin} />
+              <Text style={styles.attCheck} />
             </View>
-            <Text
-              style={[
-                styles.resolutionFooter,
-                props.isQuorate ? styles.passed : styles.rejected,
-              ]}
-            >
-              {props.isQuorate
-                ? `Határozatképes — ${
-                    props.meeting.isRepeated
-                      ? "megismételt közgyűlés (Tht. § 38(3) szerint)"
-                      : "a tulajdoni hányadok több mint 50%-a jelen van"
-                  }.`
-                : "Határozatképtelen — érdemi döntés nem hozható."}
-            </Text>
+            <View style={styles.quorumNote}>
+              <StatusPill tone={props.isQuorate ? "positive" : "negative"}>
+                {props.isQuorate
+                  ? props.meeting.isRepeated
+                    ? "Határozatképes — megismételt közgyűlés (Tht. § 38(3))"
+                    : "Határozatképes — a tulajdoni hányadok több mint 50%-a jelen"
+                  : "Határozatképtelen — érdemi döntés nem hozható"}
+              </StatusPill>
+            </View>
           </View>
         )}
 
         {/* RESOLUTIONS */}
-        <Text style={styles.sectionHeader}>Határozatok</Text>
+        <SectionTitle>Határozatok</SectionTitle>
         {props.resolutions.length === 0 ? (
-          <Text style={styles.emptyNote}>
-            Nincs határozat ehhez a közgyűléshez kötve.
-          </Text>
+          <Text style={styles.empty}>Nincs határozat ehhez a közgyűléshez kötve.</Text>
         ) : (
           props.resolutions.map((r, i) => (
-            <View key={r.id} style={styles.resolutionBox} wrap={false}>
-              <Text style={styles.miniHeader}>
-                {i + 1}. határozat{r.isSecret ? " · titkos szavazás" : ""}
-              </Text>
-              <Text style={styles.resolutionTitle}>{r.title}</Text>
-              {r.description && (
-                <Text style={styles.resolutionDesc}>{r.description}</Text>
-              )}
-              <Text style={styles.resolutionMeta}>
-                Szükséges többség: {r.majorityType} ·{" "}
-                {formatNumber(r.ballotCount)} szavazat ·{" "}
-                {formatPercent(r.totalCastWeight * 100)} hányad
-              </Text>
-              {r.options.map((o) => {
-                const pct =
-                  r.totalCastWeight > 0
-                    ? (o.weight / r.totalCastWeight) * 100
-                    : 0;
-                return (
-                  <View key={o.id} style={styles.optionRow}>
-                    <Text style={styles.optionLabel}>{o.label}</Text>
-                    <Text style={styles.optionVotes}>
-                      {formatNumber(o.ballotCount)}
-                    </Text>
-                    <Text style={styles.optionWeight}>
-                      {formatPercent(o.weight * 100)}
-                    </Text>
-                    <Text style={styles.optionShare}>{pct.toFixed(1)}%</Text>
-                  </View>
-                );
-              })}
-              <Text
-                style={[
-                  styles.resolutionFooter,
-                  r.passed === true
-                    ? styles.passed
-                    : r.passed === false
-                      ? styles.rejected
-                      : styles.pending,
-                ]}
-              >
-                {r.statutoryNote}
-              </Text>
+            <View key={r.id} style={styles.card} wrap={false}>
+              <View style={styles.cardHead}>
+                <Text style={styles.cardKicker}>
+                  {i + 1}. határozat{r.isSecret ? " · titkos" : ""}
+                </Text>
+                <Text
+                  style={r.passed === true ? styles.passed : r.passed === false ? styles.rejected : styles.pending}
+                >
+                  {r.passed === true ? "Elfogadva" : r.passed === false ? "Elutasítva" : "Nincs eredmény"}
+                </Text>
+              </View>
+              <View style={styles.cardBody}>
+                <Text style={styles.resTitle}>{r.title}</Text>
+                {r.description ? <Text style={styles.resDesc}>{r.description}</Text> : null}
+                <Text style={styles.resMeta}>
+                  {majorityLabel(r.majorityType)} · {formatNumber(r.ballotCount)} szavazat ·{" "}
+                  {formatPercent(r.totalCastWeight * 100)} hányad
+                </Text>
+                {r.options.map((o) => {
+                  const pct = r.totalCastWeight > 0 ? (o.weight / r.totalCastWeight) * 100 : 0;
+                  return (
+                    <View key={o.id} style={styles.optRow}>
+                      <Text style={styles.optLabel}>{o.label}</Text>
+                      <Text style={styles.optVotes}>{formatNumber(o.ballotCount)}</Text>
+                      <Text style={styles.optWeight}>{formatPercent(o.weight * 100)}</Text>
+                      <Text style={styles.optShare}>{pct.toFixed(1)}%</Text>
+                    </View>
+                  );
+                })}
+                <Text
+                  style={[
+                    styles.resFooter,
+                    r.passed === true ? styles.passed : r.passed === false ? styles.rejected : styles.pending,
+                  ]}
+                >
+                  {r.statutoryNote}
+                </Text>
+              </View>
             </View>
           ))
         )}
 
-        {/* MINUTES BLOB */}
-        {props.meeting.minutes && (
+        {/* MINUTES PROSE */}
+        {props.meeting.minutes ? (
           <View>
-            <Text style={styles.sectionHeader}>Jegyzőkönyv szöveg</Text>
-            <Text style={{ fontSize: 10, lineHeight: 1.6, color: "#3a4048" }}>
-              {props.meeting.minutes}
-            </Text>
+            <SectionTitle>Jegyzőkönyv szöveg</SectionTitle>
+            <Text style={styles.prose}>{props.meeting.minutes}</Text>
           </View>
-        )}
+        ) : null}
 
         {/* SIGNATURES */}
-        <Text style={styles.sectionHeader} break>
-          Aláírások · Tht. § 39
-        </Text>
-        <View style={styles.signatureGrid}>
-          {props.signatures.map((s) => (
-            <View key={s.role} style={styles.signatureCell}>
-              <Text style={styles.sigRoleLabel}>{ROLE_LABEL[s.role]}</Text>
-              {s.signerName ? (
+        <SectionTitle breakBefore>Aláírások · Tht. § 39</SectionTitle>
+        <View style={styles.sigGrid}>
+          {props.signatures.map((sig) => (
+            <View key={sig.role} style={styles.sigCell}>
+              <Text style={styles.sigRole}>{ROLE_LABEL[sig.role]}</Text>
+              {sig.signerName ? (
                 <View>
-                  <Text style={styles.sigName}>{s.signerName}</Text>
+                  <Text style={styles.sigName}>{sig.signerName}</Text>
                   <Text style={styles.sigDate}>
-                    {s.signedAt
-                      ? new Date(s.signedAt).toLocaleDateString("hu-HU", {
+                    {sig.signedAt
+                      ? new Date(sig.signedAt).toLocaleDateString("hu-HU", {
                           year: "numeric",
                           month: "long",
                           day: "numeric",
                         })
                       : ""}
                   </Text>
-                  {s.ipAddress && (
-                    <Text style={styles.sigDate}>IP: {s.ipAddress}</Text>
-                  )}
+                  {sig.ipAddress ? <Text style={styles.sigDate}>IP: {sig.ipAddress}</Text> : null}
                 </View>
               ) : (
                 <View>
                   <Text style={styles.sigPlaceholder}>(aláírásra vár)</Text>
-                  <Text style={styles.sigLine} />
+                  <View style={styles.sigLine} />
                 </View>
               )}
             </View>
           ))}
         </View>
 
-        <View style={styles.footer} fixed>
-          <Text>
-            {props.buildingName} · {formatDateTime(props.generatedAt)} · hash{" "}
-            {shortHash(props.contentHash)}
-          </Text>
-          <Text
-            style={styles.pageNum}
-            render={({ pageNumber, totalPages }) =>
-              `${pageNumber} / ${totalPages}`
-            }
-          />
-        </View>
+        <ReportFooter
+          buildingName={props.buildingName}
+          generatedAt={props.generatedAt}
+          contentHash={props.contentHash}
+        />
       </Page>
     </Document>
   );

--- a/src/reports/templates/utility-statement.tsx
+++ b/src/reports/templates/utility-statement.tsx
@@ -1,13 +1,8 @@
 import * as React from "react";
-import {
-  Document,
-  Page,
-  Text,
-  View,
-  StyleSheet,
-} from "@react-pdf/renderer";
-import { formatHUF, formatDateTime } from "../lib/format";
-import { shortHash } from "../lib/footer";
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+import { formatHUF } from "../lib/format";
+import { color, font, size, space } from "../lib/theme";
+import { ReportHeader, ReportFooter, SectionTitle } from "../lib/components";
 import type { UtilityStatementData } from "@/lib/reports/utility-statement-data";
 
 export interface UtilityStatementPdfProps extends UtilityStatementData {
@@ -17,120 +12,83 @@ export interface UtilityStatementPdfProps extends UtilityStatementData {
 
 const styles = StyleSheet.create({
   page: {
-    padding: "48 56 76 56",
-    fontSize: 10.5,
-    color: "#16181a",
-    fontFamily: "Manrope",
-    lineHeight: 1.4,
+    paddingTop: space.pageTop,
+    paddingBottom: space.pageBottom,
+    paddingHorizontal: space.pageX,
+    fontSize: size.body,
+    color: color.ink,
+    fontFamily: font.sans,
+    lineHeight: 1.45,
   },
-  eyebrow: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 500,
-    letterSpacing: -0.5,
-    lineHeight: 1.25,
-    marginBottom: 4,
-  },
-  buildingLine: {
-    fontSize: 11,
-    color: "#3a4048",
-    marginBottom: 4,
-  },
-  meta: { fontSize: 10, color: "#3a4048", marginBottom: 18 },
+
+  // Title block
+  title: { fontSize: size.title, fontWeight: 700, letterSpacing: -0.5, lineHeight: 1.2, marginBottom: 6 },
+  buildingLine: { fontSize: size.lead, fontWeight: 500, color: color.inkSoft, marginBottom: 3 },
+  meta: { fontSize: size.small, color: color.muted, marginBottom: 14 },
+
   legalNote: {
-    fontSize: 9,
-    color: "#3a4048",
-    backgroundColor: "#f6f3ec",
+    fontSize: size.small,
+    color: color.inkSoft,
+    backgroundColor: color.panel,
     padding: 10,
-    borderRadius: 5,
-    marginBottom: 18,
+    borderRadius: 6,
+    marginBottom: 4,
     lineHeight: 1.5,
   },
-  sectionHeader: {
-    fontSize: 11,
-    fontWeight: 700,
-    color: "#16181a",
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-    marginTop: 14,
-    marginBottom: 10,
-    paddingBottom: 4,
-    borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
-    borderBottomStyle: "solid",
-  },
-  rowHeader: {
+
+  // Tables
+  thRow: {
     flexDirection: "row",
-    paddingBottom: 6,
+    paddingBottom: 5,
     borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
+    borderBottomColor: color.lineStrong,
     borderBottomStyle: "solid",
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
   },
-  row: {
+  tr: {
     flexDirection: "row",
-    paddingTop: 7,
-    paddingBottom: 7,
+    paddingVertical: 4.5,
     borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
+    borderBottomColor: color.line,
     borderBottomStyle: "solid",
+    fontSize: size.small,
   },
-  rowTotal: {
+  trZebra: { backgroundColor: color.panel },
+  totalRow: {
     flexDirection: "row",
-    paddingTop: 8,
+    paddingTop: 6,
     borderTopWidth: 1,
-    borderTopColor: "#16181a",
-    borderTopStyle: "solid",
-    marginTop: 4,
+    borderTopColor: color.lineStrong,
+    marginTop: 2,
+    fontSize: size.small,
   },
+
+  // Per-utility columns
   utilName: { flex: 3 },
   utilAmount: { flex: 1.2, textAlign: "right", fontWeight: 500 },
-  utilPrev: { flex: 1.2, textAlign: "right", color: "#6c727a" },
+  utilPrev: { flex: 1.2, textAlign: "right", color: color.muted },
   utilDelta: { flex: 1, textAlign: "right" },
-  perUnitRow: {
-    flexDirection: "row",
-    paddingTop: 5,
-    paddingBottom: 5,
-    borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
-    borderBottomStyle: "solid",
-    fontSize: 9.5,
-  },
+
+  // Per-unit columns
   unitCell: { width: 50 },
   ownerCell: { flex: 2 },
-  shareCell: { width: 70, textAlign: "right", color: "#6c727a" },
+  shareCell: { width: 70, textAlign: "right", color: color.muted },
   allocCell: { width: 100, textAlign: "right", fontWeight: 500 },
-  good: { color: "#4a5a3e" },
-  bad: { color: "#a04040" },
-  emptyNote: { fontSize: 10, color: "#9a9c9f" },
-  footer: {
-    position: "absolute",
-    bottom: 32,
-    left: 56,
-    right: 56,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    fontSize: 8,
-    color: "#9a9c9f",
-    letterSpacing: 0.6,
-  },
-  pageNum: { fontFamily: "Courier" },
+
+  good: { color: color.positive },
+  bad: { color: color.negative },
+  empty: { fontSize: size.small, color: color.faint },
+
   postingNote: {
     position: "absolute",
     bottom: 50,
-    left: 56,
-    right: 56,
-    fontSize: 8.5,
-    color: "#3a4048",
+    left: space.pageX,
+    right: space.pageX,
+    fontSize: size.tiny,
+    color: color.muted,
     fontWeight: 500,
     textAlign: "center",
   },
@@ -149,7 +107,9 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
       author={props.buildingName}
     >
       <Page size="A4" style={styles.page}>
-        <Text style={styles.eyebrow}>Rezsicsökkentési kimutatás</Text>
+        <ReportHeader reportType="Rezsi kimutatás" reportRef="Tht. § 43/A" />
+
+        {/* Title block */}
         <Text style={styles.title}>{props.period.label}</Text>
         <Text style={styles.buildingLine}>{props.buildingName}</Text>
         <Text style={styles.meta}>
@@ -164,20 +124,20 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
         </Text>
 
         {/* Per-utility table */}
-        <Text style={styles.sectionHeader}>Közüzemi költségek</Text>
+        <SectionTitle>Közüzemi költségek</SectionTitle>
         {props.utilities.length === 0 ? (
-          <Text style={styles.emptyNote}>
+          <Text style={styles.empty}>
             Nincs közüzemi tétel a tárgyhónapban.
           </Text>
         ) : (
           <View>
-            <View style={styles.rowHeader}>
+            <View style={styles.thRow}>
               <Text style={styles.utilName}>Szolgáltatás</Text>
               <Text style={styles.utilAmount}>{props.period.label}</Text>
               <Text style={styles.utilPrev}>{props.prevPeriod.label}</Text>
               <Text style={styles.utilDelta}>Δ</Text>
             </View>
-            {props.utilities.map((u) => {
+            {props.utilities.map((u, i) => {
               const deltaStyle =
                 u.deltaPct === null
                   ? null
@@ -187,7 +147,7 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
                       ? styles.good
                       : null;
               return (
-                <View key={u.name} style={styles.row}>
+                <View key={u.name} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]}>
                   <Text style={styles.utilName}>{u.name}</Text>
                   <Text style={styles.utilAmount}>{formatHUF(u.amount)}</Text>
                   <Text style={styles.utilPrev}>
@@ -206,9 +166,9 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
                 </View>
               );
             })}
-            <View style={styles.rowTotal}>
-              <Text style={styles.utilName}>Összesen</Text>
-              <Text style={styles.utilAmount}>
+            <View style={styles.totalRow}>
+              <Text style={[styles.utilName, { fontWeight: 700 }]}>Összesen</Text>
+              <Text style={[styles.utilAmount, { fontWeight: 700 }]}>
                 {formatHUF(props.totalAmount)}
               </Text>
               <Text style={styles.utilPrev}>
@@ -219,6 +179,7 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
               <Text
                 style={[
                   styles.utilDelta,
+                  { fontWeight: 700 },
                   ...(totalDeltaPct === null
                     ? []
                     : totalDeltaPct > 0
@@ -237,23 +198,23 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
         )}
 
         {/* Per-unit allocation */}
-        <Text style={styles.sectionHeader}>
+        <SectionTitle>
           Albetétenkénti megosztás · tulajdoni hányad szerint
-        </Text>
+        </SectionTitle>
         {props.perUnit.length === 0 || props.totalAmount === 0 ? (
-          <Text style={styles.emptyNote}>
+          <Text style={styles.empty}>
             Nincs megosztandó összeg vagy nincs albetét rögzítve.
           </Text>
         ) : (
           <View>
-            <View style={styles.rowHeader}>
+            <View style={styles.thRow}>
               <Text style={styles.unitCell}>Albetét</Text>
               <Text style={styles.ownerCell}>Tulajdonos</Text>
               <Text style={styles.shareCell}>Hányad</Text>
               <Text style={styles.allocCell}>Havi rezsi</Text>
             </View>
-            {props.perUnit.map((p) => (
-              <View key={p.unitNumber} style={styles.perUnitRow} wrap={false}>
+            {props.perUnit.map((p, i) => (
+              <View key={p.unitNumber} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]} wrap={false}>
                 <Text style={styles.unitCell}>#{p.unitNumber}</Text>
                 <Text style={styles.ownerCell}>{p.ownerName}</Text>
                 <Text style={styles.shareCell}>
@@ -262,9 +223,9 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
                 <Text style={styles.allocCell}>{formatHUF(p.allocation)}</Text>
               </View>
             ))}
-            <View style={styles.rowTotal}>
+            <View style={styles.totalRow}>
               <Text style={styles.unitCell} />
-              <Text style={styles.ownerCell}>Összesen</Text>
+              <Text style={[styles.ownerCell, { fontWeight: 700 }]}>Összesen</Text>
               <Text style={styles.shareCell}>
                 {(
                   props.perUnit.reduce(
@@ -274,7 +235,7 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
                 ).toFixed(2)}
                 %
               </Text>
-              <Text style={styles.allocCell}>
+              <Text style={[styles.allocCell, { fontWeight: 700 }]}>
                 {formatHUF(
                   props.perUnit.reduce((s, p) => s + p.allocation, 0),
                 )}
@@ -287,18 +248,11 @@ export function UtilityStatementPdf(props: UtilityStatementPdfProps) {
           Hirdetőtáblán kifüggesztve · Tht. § 43/A · legalább 45 napig
         </Text>
 
-        <View style={styles.footer} fixed>
-          <Text>
-            {props.buildingName} · {formatDateTime(props.generatedAt)} · hash{" "}
-            {shortHash(props.contentHash)}
-          </Text>
-          <Text
-            style={styles.pageNum}
-            render={({ pageNumber, totalPages }) =>
-              `${pageNumber} / ${totalPages}`
-            }
-          />
-        </View>
+        <ReportFooter
+          buildingName={props.buildingName}
+          generatedAt={props.generatedAt}
+          contentHash={props.contentHash}
+        />
       </Page>
     </Document>
   );

--- a/src/reports/templates/vote-result.tsx
+++ b/src/reports/templates/vote-result.tsx
@@ -1,18 +1,8 @@
 import * as React from "react";
-import {
-  Document,
-  Page,
-  Text,
-  View,
-  StyleSheet,
-} from "@react-pdf/renderer";
-import {
-  formatDate,
-  formatDateTime,
-  formatPercent,
-  formatNumber,
-} from "../lib/format";
-import { shortHash } from "../lib/footer";
+import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+import { formatDate, formatPercent, formatNumber } from "../lib/format";
+import { color, font, size, space, majorityLabel } from "../lib/theme";
+import { ReportHeader, ReportFooter, SectionTitle, StatusPill } from "../lib/components";
 
 export interface VoteResultPdfProps {
   buildingName: string;
@@ -47,144 +37,69 @@ export interface VoteResultPdfProps {
 
 const styles = StyleSheet.create({
   page: {
-    padding: "48 56 64 56",
-    fontSize: 10.5,
-    color: "#16181a",
-    fontFamily: "Manrope",
-    lineHeight: 1.4,
+    paddingTop: space.pageTop,
+    paddingBottom: space.pageBottom,
+    paddingHorizontal: space.pageX,
+    fontSize: size.body,
+    color: color.ink,
+    fontFamily: font.sans,
+    lineHeight: 1.45,
   },
-  eyebrow: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 500,
-    letterSpacing: -0.5,
-    lineHeight: 1.25,
-    marginBottom: 8,
-    color: "#16181a",
-  },
-  buildingLine: {
-    fontSize: 11,
-    color: "#3a4048",
-    marginBottom: 28,
-  },
-  sectionHeader: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.2,
-    textTransform: "uppercase",
-    marginBottom: 6,
-    marginTop: 8,
-  },
-  description: {
-    fontSize: 10.5,
-    lineHeight: 1.55,
-    marginBottom: 16,
-    color: "#3a4048",
-  },
-  kpiRow: {
-    flexDirection: "row",
-    marginBottom: 24,
-    gap: 8,
-  },
+
+  // Title block
+  title: { fontSize: size.title, fontWeight: 700, letterSpacing: -0.5, lineHeight: 1.2, marginBottom: 6 },
+  buildingLine: { fontSize: size.lead, fontWeight: 500, color: color.inkSoft, marginBottom: 3 },
+  meta: { fontSize: size.small, color: color.muted, marginBottom: 14 },
+
+  description: { fontSize: size.body, lineHeight: 1.6, color: color.inkSoft, marginBottom: 4 },
+
+  // KPI cards
+  kpiRow: { flexDirection: "row", gap: 10, marginBottom: 4 },
   kpiCell: {
     flex: 1,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: color.panelEdge,
+    borderStyle: "solid",
+    borderRadius: 8,
     padding: 12,
   },
   kpiLabel: {
-    fontSize: 8,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
-    marginBottom: 4,
+    marginBottom: 6,
   },
-  kpiValue: {
-    fontSize: 18,
-    fontWeight: 500,
-    color: "#16181a",
-  },
-  kpiSub: {
-    fontSize: 9,
-    color: "#6c727a",
-    marginTop: 2,
-  },
-  resultRow: {
+  kpiValue: { fontSize: 18, fontWeight: 700, color: color.ink },
+  kpiSub: { fontSize: size.micro, color: color.muted, marginTop: 2 },
+
+  // Options table
+  thRow: {
     flexDirection: "row",
-    paddingTop: 8,
-    paddingBottom: 8,
-    borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
-    borderBottomStyle: "solid",
-  },
-  resultRowHeader: {
-    flexDirection: "row",
-    paddingBottom: 6,
+    paddingBottom: 5,
     borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
+    borderBottomColor: color.lineStrong,
     borderBottomStyle: "solid",
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
   },
-  optionLabel: {
-    flex: 3,
-  },
-  optionBallots: {
-    flex: 1,
-    textAlign: "right",
-  },
-  optionShare: {
-    flex: 1,
-    textAlign: "right",
-  },
-  optionPercent: {
-    flex: 1,
-    textAlign: "right",
-    fontWeight: 500,
-  },
-  outcomeBox: {
-    marginTop: 28,
-    padding: 14,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 6,
-    backgroundColor: "#f6f3ec",
-  },
-  outcomeLabel: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.2,
-    textTransform: "uppercase",
-    marginBottom: 4,
-  },
-  outcomeValue: {
-    fontSize: 14,
-    fontWeight: 500,
-  },
-  outcomePassed: { color: "#4a5a3e" },
-  outcomeRejected: { color: "#a04040" },
-  outcomePending: { color: "#6c727a" },
-  footer: {
-    position: "absolute",
-    bottom: 32,
-    left: 56,
-    right: 56,
+  tr: {
     flexDirection: "row",
-    justifyContent: "space-between",
-    fontSize: 8,
-    color: "#9a9c9f",
-    letterSpacing: 0.6,
+    paddingVertical: 4.5,
+    borderBottomWidth: 0.5,
+    borderBottomColor: color.line,
+    borderBottomStyle: "solid",
+    fontSize: size.small,
   },
-  pageNum: {
-    fontFamily: "Courier",
-  },
+  trZebra: { backgroundColor: color.panel },
+  optLabel: { flex: 3 },
+  optBallots: { flex: 1, textAlign: "right" },
+  optShare: { flex: 1, textAlign: "right", color: color.muted },
+  optPercent: { flex: 1, textAlign: "right", fontWeight: 700 },
+
+  outcomeNote: { marginTop: 16 },
 });
 
 export function VoteResultPdf(props: VoteResultPdfProps) {
@@ -192,120 +107,93 @@ export function VoteResultPdf(props: VoteResultPdfProps) {
     ? (props.totalCastWeight / props.totalEligibleWeight) * 100
     : 0;
   const isClosed = props.vote.status === "CLOSED";
-  const outcomeText =
-    !isClosed
-      ? "Folyamatban"
-      : props.vote.passed === true
-        ? "Elfogadva"
-        : props.vote.passed === false
-          ? "Elutasítva"
-          : "Lezárva";
-  const outcomeStyle =
-    !isClosed
-      ? styles.outcomePending
-      : props.vote.passed === true
-        ? styles.outcomePassed
-        : props.vote.passed === false
-          ? styles.outcomeRejected
-          : styles.outcomePending;
+  const outcomeText = !isClosed
+    ? "Folyamatban"
+    : props.vote.passed === true
+      ? "Elfogadva"
+      : props.vote.passed === false
+        ? "Elutasítva"
+        : "Lezárva";
+  const outcomeTone: "positive" | "negative" | "neutral" = !isClosed
+    ? "neutral"
+    : props.vote.passed === true
+      ? "positive"
+      : props.vote.passed === false
+        ? "negative"
+        : "neutral";
 
   return (
-    <Document
-      title={`Szavazás eredménye — ${props.vote.title}`}
-      author={props.buildingName}
-    >
+    <Document title={`Szavazás eredménye — ${props.vote.title}`} author={props.buildingName}>
       <Page size="A4" style={styles.page}>
-        <Text style={styles.eyebrow}>Szavazás eredménye</Text>
+        <ReportHeader reportType="Szavazási eredmény" />
+
+        {/* Title block */}
         <Text style={styles.title}>{props.vote.title}</Text>
-        <Text style={styles.buildingLine}>
-          {props.buildingName} · határidő{" "}
-          {formatDate(props.vote.deadline)}
+        <Text style={styles.buildingLine}>{props.buildingName}</Text>
+        <Text style={styles.meta}>
+          Határidő · {formatDate(props.vote.deadline)}
+          {props.vote.isSecret ? " · titkos szavazás" : ""}
         </Text>
 
+        {/* DESCRIPTION */}
         {props.vote.description && (
-          <>
-            <Text style={styles.sectionHeader}>Leírás</Text>
+          <View>
+            <SectionTitle>Leírás</SectionTitle>
             <Text style={styles.description}>{props.vote.description}</Text>
-          </>
+          </View>
         )}
 
+        {/* KPIs */}
+        <SectionTitle>Részvétel · határozatképesség</SectionTitle>
         <View style={styles.kpiRow}>
           <View style={styles.kpiCell}>
             <Text style={styles.kpiLabel}>Jogosult tulajdoni hányad</Text>
-            <Text style={styles.kpiValue}>
-              {formatPercent(props.totalEligibleWeight * 100)}
-            </Text>
-            <Text style={styles.kpiSub}>{"100% hányad"}</Text>
+            <Text style={styles.kpiValue}>{formatPercent(props.totalEligibleWeight * 100)}</Text>
+            <Text style={styles.kpiSub}>100% hányad</Text>
           </View>
           <View style={styles.kpiCell}>
             <Text style={styles.kpiLabel}>Leadott szavazat</Text>
-            <Text style={styles.kpiValue}>
-              {formatPercent(props.totalCastWeight * 100)}
-            </Text>
-            <Text style={styles.kpiSub}>
-              {formatNumber(props.ballotCount)} szavazó
-            </Text>
+            <Text style={styles.kpiValue}>{formatPercent(props.totalCastWeight * 100)}</Text>
+            <Text style={styles.kpiSub}>{formatNumber(props.ballotCount)} szavazó</Text>
           </View>
           <View style={styles.kpiCell}>
             <Text style={styles.kpiLabel}>Részvétel</Text>
             <Text style={styles.kpiValue}>{formatPercent(turnoutPct)}</Text>
-            <Text style={styles.kpiSub}>
-              {props.vote.majorityType === "SIMPLE_MAJORITY"
-                ? "egyszerű többség"
-                : props.vote.majorityType === "TWO_THIRDS"
-                  ? "kétharmados"
-                  : props.vote.majorityType === "UNANIMOUS"
-                    ? "egyhangú"
-                    : props.vote.majorityType}
-            </Text>
+            <Text style={styles.kpiSub}>{majorityLabel(props.vote.majorityType)}</Text>
           </View>
         </View>
 
-        <Text style={styles.sectionHeader}>Eredmények opciónként</Text>
-        <View style={styles.resultRowHeader}>
-          <Text style={styles.optionLabel}>Opció</Text>
-          <Text style={styles.optionBallots}>Szavazat</Text>
-          <Text style={styles.optionShare}>Hányad</Text>
-          <Text style={styles.optionPercent}>Arány</Text>
+        {/* OPTIONS */}
+        <SectionTitle>Eredmények opciónként</SectionTitle>
+        <View style={styles.thRow}>
+          <Text style={styles.optLabel}>Opció</Text>
+          <Text style={styles.optBallots}>Szavazat</Text>
+          <Text style={styles.optShare}>Hányad</Text>
+          <Text style={styles.optPercent}>Arány</Text>
         </View>
-        {props.options.map((o) => {
-          const pctOfCast =
-            props.totalCastWeight > 0
-              ? (o.weight / props.totalCastWeight) * 100
-              : 0;
+        {props.options.map((o, i) => {
+          const pctOfCast = props.totalCastWeight > 0 ? (o.weight / props.totalCastWeight) * 100 : 0;
           return (
-            <View key={o.id} style={styles.resultRow}>
-              <Text style={styles.optionLabel}>{o.label}</Text>
-              <Text style={styles.optionBallots}>
-                {formatNumber(o.ballotCount)}
-              </Text>
-              <Text style={styles.optionShare}>
-                {formatPercent(o.weight * 100)}
-              </Text>
-              <Text style={styles.optionPercent}>
-                {formatPercent(pctOfCast)}
-              </Text>
+            <View key={o.id} style={[styles.tr, i % 2 === 1 ? styles.trZebra : {}]} wrap={false}>
+              <Text style={styles.optLabel}>{o.label}</Text>
+              <Text style={styles.optBallots}>{formatNumber(o.ballotCount)}</Text>
+              <Text style={styles.optShare}>{formatPercent(o.weight * 100)}</Text>
+              <Text style={styles.optPercent}>{formatPercent(pctOfCast)}</Text>
             </View>
           );
         })}
 
-        <View style={styles.outcomeBox}>
-          <Text style={styles.outcomeLabel}>Végeredmény</Text>
-          <Text style={[styles.outcomeValue, outcomeStyle]}>{outcomeText}</Text>
+        {/* OUTCOME */}
+        <SectionTitle>Végeredmény</SectionTitle>
+        <View style={styles.outcomeNote}>
+          <StatusPill tone={outcomeTone}>{outcomeText}</StatusPill>
         </View>
 
-        <View style={styles.footer} fixed>
-          <Text>
-            {props.buildingName} · {formatDateTime(props.generatedAt)} ·
-            hash {shortHash(props.contentHash)}
-          </Text>
-          <Text
-            style={styles.pageNum}
-            render={({ pageNumber, totalPages }) =>
-              `${pageNumber} / ${totalPages}`
-            }
-          />
-        </View>
+        <ReportFooter
+          buildingName={props.buildingName}
+          generatedAt={props.generatedAt}
+          contentHash={props.contentHash}
+        />
       </Page>
     </Document>
   );

--- a/src/reports/templates/year-end-account.tsx
+++ b/src/reports/templates/year-end-account.tsx
@@ -6,8 +6,9 @@ import {
   View,
   StyleSheet,
 } from "@react-pdf/renderer";
-import { formatHUF, formatDateTime } from "../lib/format";
-import { shortHash } from "../lib/footer";
+import { formatHUF } from "../lib/format";
+import { color, font, size, space } from "../lib/theme";
+import { ReportHeader, ReportFooter, SectionTitle, StatusPill } from "../lib/components";
 import type { YearEndAccountData } from "@/lib/reports/year-end-account-data";
 
 export interface YearEndAccountPdfProps extends YearEndAccountData {
@@ -28,44 +29,20 @@ export interface YearEndAccountPdfProps extends YearEndAccountData {
 
 const styles = StyleSheet.create({
   page: {
-    padding: "48 56 64 56",
-    fontSize: 10.5,
-    color: "#16181a",
-    fontFamily: "Manrope",
-    lineHeight: 1.4,
+    paddingTop: space.pageTop,
+    paddingBottom: space.pageBottom,
+    paddingHorizontal: space.pageX,
+    fontSize: size.body,
+    color: color.ink,
+    fontFamily: font.sans,
+    lineHeight: 1.45,
   },
-  eyebrow: {
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 500,
-    letterSpacing: -0.5,
-    lineHeight: 1.2,
-    marginBottom: 4,
-  },
-  buildingLine: {
-    fontSize: 11,
-    color: "#3a4048",
-    marginBottom: 24,
-  },
-  sectionHeader: {
-    fontSize: 11,
-    fontWeight: 700,
-    color: "#16181a",
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-    marginTop: 18,
-    marginBottom: 10,
-    paddingBottom: 4,
-    borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
-    borderBottomStyle: "solid",
-  },
+
+  // Title block
+  title: { fontSize: size.title, fontWeight: 700, letterSpacing: -0.5, lineHeight: 1.2, marginBottom: 6 },
+  buildingLine: { fontSize: size.lead, fontWeight: 500, color: color.inkSoft, marginBottom: 3 },
+  meta: { fontSize: size.small, color: color.muted, marginBottom: 14 },
+
   kpiRow: {
     flexDirection: "row",
     marginBottom: 16,
@@ -73,89 +50,73 @@ const styles = StyleSheet.create({
   },
   kpiCell: {
     flex: 1,
-    border: "1pt solid #d4d2cc",
-    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: color.panelEdge,
+    borderStyle: "solid",
+    borderRadius: 8,
     padding: 12,
   },
   kpiLabel: {
-    fontSize: 8,
-    color: "#6c727a",
+    fontSize: size.tiny,
+    color: color.muted,
     letterSpacing: 1.1,
     textTransform: "uppercase",
     marginBottom: 4,
   },
-  kpiValue: { fontSize: 16, fontWeight: 500 },
-  kpiSub: { fontSize: 9, color: "#6c727a", marginTop: 2 },
-  good: { color: "#4a5a3e" },
-  bad: { color: "#a04040" },
+  kpiValue: { fontSize: 16, fontWeight: 700 },
+  kpiSub: { fontSize: size.micro, color: color.muted, marginTop: 2 },
+  good: { color: color.positive },
+  bad: { color: color.negative },
+
+  // Tables
   rowHeader: {
     flexDirection: "row",
-    paddingBottom: 6,
+    paddingBottom: 5,
     borderBottomWidth: 1,
-    borderBottomColor: "#16181a",
+    borderBottomColor: color.lineStrong,
     borderBottomStyle: "solid",
-    fontSize: 9,
-    color: "#6c727a",
-    letterSpacing: 1.1,
+    fontSize: size.micro,
+    color: color.muted,
+    letterSpacing: 0.8,
     textTransform: "uppercase",
   },
   row: {
     flexDirection: "row",
-    paddingTop: 6,
-    paddingBottom: 6,
+    paddingVertical: 4.5,
     borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
+    borderBottomColor: color.line,
     borderBottomStyle: "solid",
+    fontSize: size.small,
   },
   rowTotal: {
     flexDirection: "row",
-    paddingTop: 8,
+    paddingTop: 6,
     borderTopWidth: 1,
-    borderTopColor: "#16181a",
+    borderTopColor: color.lineStrong,
     borderTopStyle: "solid",
-    marginTop: 4,
+    marginTop: 2,
   },
   cellName: { flex: 3 },
   cellAmount: { flex: 1, textAlign: "right", fontWeight: 500 },
-  cellShare: { flex: 1, textAlign: "right", color: "#6c727a" },
-  cellRatio: { flex: 1, textAlign: "right", color: "#6c727a" },
+  cellShare: { flex: 1, textAlign: "right", color: color.muted },
+  cellRatio: { flex: 1, textAlign: "right", color: color.muted },
   twoCol: { flexDirection: "row", gap: 16, marginBottom: 8 },
   twoColCell: { flex: 1 },
-  miniHeader: {
-    fontSize: 9,
-    fontWeight: 700,
-    color: "#3a4048",
-    letterSpacing: 0.6,
-    textTransform: "uppercase",
-    marginBottom: 6,
-  },
-  emptyNote: { fontSize: 10, color: "#9a9c9f" },
+
+  emptyNote: { fontSize: size.small, color: color.faint },
   perOwnerRow: {
     flexDirection: "row",
-    paddingTop: 5,
-    paddingBottom: 5,
+    paddingVertical: 4.5,
     borderBottomWidth: 0.5,
-    borderBottomColor: "#d4d2cc",
+    borderBottomColor: color.line,
     borderBottomStyle: "solid",
-    fontSize: 9.5,
+    fontSize: size.small,
   },
   unitCell: { width: 50 },
   ownerCell: { flex: 2 },
-  shareCell: { width: 60, textAlign: "right", color: "#6c727a" },
+  shareCell: { width: 60, textAlign: "right", color: color.muted },
   amountCell: { width: 90, textAlign: "right" },
   outstandingCell: { width: 90, textAlign: "right" },
-  footer: {
-    position: "absolute",
-    bottom: 32,
-    left: 56,
-    right: 56,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    fontSize: 8,
-    color: "#9a9c9f",
-    letterSpacing: 0.6,
-  },
-  pageNum: { fontFamily: "Courier" },
   watermark: {
     position: "absolute",
     // Visually centred on an A4 page (595×842 pt) with the rotation
@@ -168,19 +129,19 @@ const styles = StyleSheet.create({
     fontSize: 110,
     fontWeight: 500,
     letterSpacing: 14,
-    color: "#16181a",
+    color: color.ink,
     opacity: 0.08,
     transform: "rotate(-30deg)",
   },
   approvedBanner: {
-    fontSize: 9.5,
-    color: "#4a5a3e",
-    backgroundColor: "color-mix(in srgb, #4a5a3e 14%, transparent)",
+    fontSize: size.small,
+    color: color.positive,
+    backgroundColor: color.positiveTint,
     padding: 8,
     borderRadius: 5,
     marginBottom: 18,
     borderLeftWidth: 3,
-    borderLeftColor: "#4a5a3e",
+    borderLeftColor: color.positive,
   },
 });
 
@@ -202,11 +163,20 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
           </Text>
         )}
 
-        <Text style={styles.eyebrow}>
-          Éves pénzügyi elszámolás{isDraft ? " · tervezet" : ""}
-        </Text>
+        <ReportHeader reportType="Éves elszámolás" />
+
+        {/* Title block */}
         <Text style={styles.title}>{props.year}. év</Text>
         <Text style={styles.buildingLine}>{props.buildingName}</Text>
+        <Text style={styles.meta}>
+          Éves pénzügyi elszámolás{isDraft ? " · tervezet" : ""}
+        </Text>
+
+        {isDraft ? (
+          <StatusPill tone="warning">Tervezet · a közgyűlés jóváhagyásáig</StatusPill>
+        ) : (
+          <StatusPill tone="positive">Elfogadva a közgyűlés által</StatusPill>
+        )}
 
         {!isDraft && props.approvedAt && (
           <Text style={styles.approvedBanner}>
@@ -250,7 +220,7 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
         {/* ASSETS + LIABILITIES side by side */}
         <View style={styles.twoCol}>
           <View style={styles.twoColCell}>
-            <Text style={styles.sectionHeader}>Vagyon</Text>
+            <SectionTitle>Vagyon</SectionTitle>
             {props.assets.length === 0 ? (
               <Text style={styles.emptyNote}>Nincs vagyoni tétel.</Text>
             ) : (
@@ -273,7 +243,7 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
             )}
           </View>
           <View style={styles.twoColCell}>
-            <Text style={styles.sectionHeader}>Kötelezettségek</Text>
+            <SectionTitle>Kötelezettségek</SectionTitle>
             {props.liabilities.length === 0 && props.arrears.total === 0 ? (
               <Text style={styles.emptyNote}>Nincs nyitott kötelezettség.</Text>
             ) : (
@@ -300,7 +270,7 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
         </View>
 
         {/* BUDGET vs ACTUAL */}
-        <Text style={styles.sectionHeader}>Költségvetés terv vs. tény</Text>
+        <SectionTitle>Költségvetés terv vs. tény</SectionTitle>
         {props.budget.length === 0 ? (
           <Text style={styles.emptyNote}>Nincs évre rögzített költségvetés.</Text>
         ) : (
@@ -354,7 +324,7 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
         )}
 
         {/* EXPENSE CATEGORIES */}
-        <Text style={styles.sectionHeader}>Kiadások kategóriánként</Text>
+        <SectionTitle>Kiadások kategóriánként</SectionTitle>
         {props.expenseByCategory.length === 0 ? (
           <Text style={styles.emptyNote}>Nincs kiadás az évben.</Text>
         ) : (
@@ -385,9 +355,7 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
         {/* REZSI */}
         {props.rezsiBreakdown.length > 0 && (
           <View>
-            <Text style={styles.sectionHeader}>
-              Rezsi — közüzemi költségek éves bontása
-            </Text>
+            <SectionTitle>Rezsi — közüzemi költségek éves bontása</SectionTitle>
             <View style={styles.rowHeader}>
               <Text style={styles.cellName}>Számla</Text>
               <Text style={styles.cellAmount}>Éves összeg</Text>
@@ -410,31 +378,17 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
         )}
 
         {/* PER OWNER */}
-        <Text style={styles.sectionHeader} break>
-          Tulajdonosi költségmegosztás
-        </Text>
+        <SectionTitle breakBefore>Tulajdonosi költségmegosztás</SectionTitle>
         {props.perOwner.length === 0 ? (
           <Text style={styles.emptyNote}>Nincs albetét rögzítve.</Text>
         ) : (
           <View>
-            <View
-              style={[
-                styles.perOwnerRow,
-                {
-                  borderBottomWidth: 1,
-                  borderBottomColor: "#16181a",
-                  paddingTop: 0,
-                  paddingBottom: 6,
-                },
-              ]}
-            >
-              <Text style={[styles.unitCell, styles.kpiLabel]}>Albetét</Text>
-              <Text style={[styles.ownerCell, styles.kpiLabel]}>Tulajdonos</Text>
-              <Text style={[styles.shareCell, styles.kpiLabel]}>Hányad</Text>
-              <Text style={[styles.amountCell, styles.kpiLabel]}>Befizetett</Text>
-              <Text style={[styles.outstandingCell, styles.kpiLabel]}>
-                Hátralék
-              </Text>
+            <View style={styles.rowHeader}>
+              <Text style={styles.unitCell}>Albetét</Text>
+              <Text style={styles.ownerCell}>Tulajdonos</Text>
+              <Text style={styles.shareCell}>Hányad</Text>
+              <Text style={styles.amountCell}>Befizetett</Text>
+              <Text style={styles.outstandingCell}>Hátralék</Text>
             </View>
             {props.perOwner.map((p) => (
               <View key={p.unitNumber} style={styles.perOwnerRow} wrap={false}>
@@ -477,18 +431,11 @@ export function YearEndAccountPdf(props: YearEndAccountPdfProps) {
           </View>
         )}
 
-        <View style={styles.footer} fixed>
-          <Text>
-            {props.buildingName} · {formatDateTime(props.generatedAt)} · hash{" "}
-            {shortHash(props.contentHash)}
-          </Text>
-          <Text
-            style={styles.pageNum}
-            render={({ pageNumber, totalPages }) =>
-              `${pageNumber} / ${totalPages}`
-            }
-          />
-        </View>
+        <ReportFooter
+          buildingName={props.buildingName}
+          generatedAt={props.generatedAt}
+          contentHash={props.contentHash}
+        />
       </Page>
     </Document>
   );


### PR DESCRIPTION
A full visual refresh of the PDF reports onto a shared design system — consistent, branded, and fixing two real rendering bugs.

## What's new
- **`src/reports/lib/theme.ts`** — color / type / space tokens (all literal — react-pdf has no `color-mix`/`var`) + `majorityLabel()` for Hungarian majority-type names.
- **`src/reports/lib/components.tsx`** — `ReportHeader` (Közös **wordmark** + ochre report label + rule), `ReportFooter` (hash + page n/n), `SectionTitle`, `StatusPill`, `Wordmark`.
- **All 7 templates** refactored onto it (minutes, vote-result, meeting-summary, finance-summary, year-end-account, utility-statement, audit-slice): branded header band, **status pills** instead of full-width banners, zebra tables with bold totals, card-style groupings, unified palette + footer.

## Bugs fixed during the refresh
- **`color-mix()` backgrounds rendered black** in react-pdf (minutes draft/executed banners, year-end approved banner) → flat theme tints.
- **`majorityType` printed the raw enum** (`SIMPLE_MAJORITY`) in minutes / vote-result / meeting-summary → `majorityLabel()` → "Egyszerű többség".

## Verification
- Data, props, and computed logic unchanged across all templates — presentation only.
- **279 tests pass** (incl. the vote-PDF render test); tsc + lint clean.
- **Jegyzőkönyv** (your approved sample) and **vote-result** render-verified locally; I'll generate the full set on prod after deploy to confirm none fail.

Approved design sample: the jegyzőkönyv artifact shared earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)