### PR TITLE
feat(voting): multi-unit owners cast one ballot per owned unit

### DIFF
--- a/src/app/api/voting/votes/[id]/ballot/route.ts
+++ b/src/app/api/voting/votes/[id]/ballot/route.ts
@@ -64,40 +64,35 @@ export async function POST(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: "Invalid option for this vote" }, { status: 400 });
     }
 
-    let unitId: string;
     let castById: string | null = null;
-    let ballotUserId: string | null = vote.isSecret ? null : userId;
+    // Units this request will cast for. Self-voting fans out across ALL of the
+    // owner's units (one ballot each, same option) so their full ownership
+    // weight counts; proxy / on-behalf target a single unit.
+    let targets: { unitId: string; ballotUserId: string | null }[] = [];
 
     if (onBehalfOfUnitId) {
-      // "Cast on behalf" — organizer/board member votes for another unit
-      const isBoardPlus = allows(ctx, "vote.cast");
-      if (!isBoardPlus) {
+      // "Cast on behalf" — organizer/board member votes for another unit.
+      if (!allows(ctx, "vote.cast")) {
         return NextResponse.json(
           { error: "Only board members can cast votes on behalf of others" },
           { status: 403 }
         );
       }
-
-      // Verify the unit belongs to this building
       const unit = await prisma.unit.findFirst({
         where: { id: onBehalfOfUnitId, buildingId },
+        select: { id: true },
       });
       if (!unit) {
         return NextResponse.json({ error: "Unit not found in this building" }, { status: 404 });
       }
-
-      unitId = onBehalfOfUnitId;
       castById = userId;
-
-      // Find the unit owner for ballot attribution
       const unitOwner = await prisma.unitUser.findFirst({
         where: { unitId: onBehalfOfUnitId, isPrimaryContact: true },
         select: { userId: true },
       });
-      ballotUserId = vote.isSecret ? null : (unitOwner?.userId ?? null);
-
+      targets = [{ unitId: onBehalfOfUnitId, ballotUserId: vote.isSecret ? null : unitOwner?.userId ?? null }];
     } else if (proxyForUnitId) {
-      // Proxy voting — existing logic
+      // Proxy voting — grantee casts for the grantor's unit.
       const userUnit = await prisma.unitUser.findFirst({
         where: { userId, unit: { buildingId } },
         select: { unitId: true },
@@ -105,134 +100,112 @@ export async function POST(request: NextRequest, context: RouteContext) {
       if (!userUnit) {
         return NextResponse.json({ error: "No unit found in this building" }, { status: 400 });
       }
-
       const now = new Date();
       const proxy = await prisma.proxyAssignment.findFirst({
         where: {
           granteeId: userId,
-          grantor: {
-            unitUsers: { some: { unitId: proxyForUnitId } },
-          },
+          grantor: { unitUsers: { some: { unitId: proxyForUnitId } } },
           validFrom: { lte: now },
           AND: [
-            {
-              OR: [
-                { voteId: voteId },
-                { voteId: null },
-              ],
-            },
-            {
-              OR: [
-                { validUntil: null },
-                { validUntil: { gte: now } },
-              ],
-            },
+            { OR: [{ voteId: voteId }, { voteId: null }] },
+            { OR: [{ validUntil: null }, { validUntil: { gte: now } }] },
           ],
         },
       });
-
       if (!proxy) {
-        return NextResponse.json(
-          { error: "No valid proxy assignment found" },
-          { status: 403 }
-        );
+        return NextResponse.json({ error: "No valid proxy assignment found" }, { status: 403 });
       }
-
-      unitId = proxyForUnitId;
+      targets = [{ unitId: proxyForUnitId, ballotUserId: vote.isSecret ? null : userId }];
     } else {
       // Self-voting — only owners may cast (Tht. § 38); tenants are excluded.
       if (!allows(ctx, "vote.cast")) {
-        return NextResponse.json(
-          { error: "Only owners can cast a vote" },
-          { status: 403 }
-        );
+        return NextResponse.json({ error: "Only owners can cast a vote" }, { status: 403 });
       }
-      const userUnit = await prisma.unitUser.findFirst({
+      const ownerUnits = await prisma.unitUser.findMany({
         where: { userId, relationship: "OWNER", unit: { buildingId } },
         select: { unitId: true },
       });
-      if (!userUnit) {
+      if (ownerUnits.length === 0) {
         return NextResponse.json({ error: "No unit found in this building" }, { status: 400 });
       }
-      unitId = userUnit.unitId;
+      let unitIds = ownerUnits.map((u) => u.unitId);
 
-      // Presence gate: for a vote held inside a meeting, the owner's unit must
-      // be checked in (présent). The companion self-checks-in on joining the
-      // live view; the board uses "Érkeztetés" for people in the room. Proxy
-      // (represented) and board on-behalf casts have their own paths above and
-      // are intentionally not gated here.
+      // Presence gate: for a vote inside a meeting, only checked-in units may
+      // vote (the companion self-checks-in on joining; the board uses
+      // "Érkeztetés"). Cast for the present subset; reject if none are present.
       if (vote.meetingId) {
-        const attendance = await prisma.meetingAttendance.findUnique({
-          where: { meetingId_unitId: { meetingId: vote.meetingId, unitId } },
+        const present = await prisma.meetingAttendance.findMany({
+          where: {
+            meetingId: vote.meetingId,
+            unitId: { in: unitIds },
+            checkedIn: true,
+            checkedOutAt: null,
+          },
+          select: { unitId: true },
         });
-        if (!attendance || !attendance.checkedIn || attendance.checkedOutAt) {
+        const presentSet = new Set(present.map((p) => p.unitId));
+        unitIds = unitIds.filter((id) => presentSet.has(id));
+        if (unitIds.length === 0) {
           return NextResponse.json({ error: "NOT_CHECKED_IN" }, { status: 403 });
         }
       }
+      targets = unitIds.map((id) => ({ unitId: id, ballotUserId: vote.isSecret ? null : userId }));
     }
 
-    // Check if this unit already voted
-    const existingBallot = await prisma.ballot.findUnique({
-      where: { voteId_unitId: { voteId, unitId } },
+    // Skip units that already voted; 409 only if none remain.
+    const already = await prisma.ballot.findMany({
+      where: { voteId, unitId: { in: targets.map((t) => t.unitId) } },
+      select: { unitId: true },
     });
-
-    if (existingBallot) {
+    const votedSet = new Set(already.map((b) => b.unitId));
+    const fresh = targets.filter((t) => !votedSet.has(t.unitId));
+    if (fresh.length === 0) {
       return NextResponse.json(
         { error: "This unit has already cast a ballot for this vote" },
         { status: 409 }
       );
     }
 
-    // Get unit's ownership share for weight
-    const unit = await prisma.unit.findUnique({
-      where: { id: unitId },
-      select: { ownershipShare: true },
+    const units = await prisma.unit.findMany({
+      where: { id: { in: fresh.map((t) => t.unitId) } },
+      select: { id: true, ownershipShare: true },
     });
+    const shareById = new Map(units.map((u) => [u.id, u.ownershipShare]));
 
-    if (!unit) {
-      return NextResponse.json({ error: "Unit not found" }, { status: 404 });
-    }
-
-    // Create ballot
-    const ballot = await prisma.ballot.create({
-      data: {
-        voteId,
-        optionId,
-        unitId,
-        userId: ballotUserId,
-        castById,
-        weight: unit.ownershipShare,
-        receiptHash: null,
-      },
-    });
-
-    let receiptHash: string | null = null;
-
+    let secret: string | null = null;
     if (vote.isSecret) {
-      const secret = process.env.BALLOT_SECRET;
+      secret = process.env.BALLOT_SECRET ?? null;
       if (!secret) {
         return NextResponse.json(
           { error: "Voting system configuration error. Contact administrator." },
           { status: 500 }
         );
       }
-      receiptHash = createHash("sha256")
-        .update(ballot.id + secret)
-        .digest("hex");
+    }
 
-      await prisma.ballot.update({
-        where: { id: ballot.id },
-        data: { receiptHash },
+    // Fan out: one ballot per target unit (same option).
+    const created: { id: string; unitId: string; weight: number; receiptHash: string | null }[] = [];
+    for (const t of fresh) {
+      const share = shareById.get(t.unitId);
+      if (share === undefined) continue;
+      const ballot = await prisma.ballot.create({
+        data: { voteId, optionId, unitId: t.unitId, userId: t.ballotUserId, castById, weight: share, receiptHash: null },
       });
+      let receiptHash: string | null = null;
+      if (secret) {
+        receiptHash = createHash("sha256").update(ballot.id + secret).digest("hex");
+        await prisma.ballot.update({ where: { id: ballot.id }, data: { receiptHash } });
+      }
+      created.push({ id: ballot.id, unitId: t.unitId, weight: Number(share), receiptHash });
     }
 
     await ballotCast({
-      ballotId: ballot.id,
+      ballotId: created[0].id,
       voterUserId: userId,
       buildingId,
       newValue: {
         voteId,
-        unitId,
+        unitIds: created.map((c) => c.unitId),
         isProxy: !!proxyForUnitId,
         isOnBehalf: !!onBehalfOfUnitId,
         isSecret: vote.isSecret,
@@ -248,14 +221,20 @@ export async function POST(request: NextRequest, context: RouteContext) {
       });
     }
 
-    return NextResponse.json({
-      id: ballot.id,
-      voteId: ballot.voteId,
-      optionId: ballot.optionId,
-      weight: Number(ballot.weight),
-      receiptHash,
-      castOnBehalf: !!castById,
-    }, { status: 201 });
+    return NextResponse.json(
+      {
+        // Back-compat single-ballot fields (first/only unit) + aggregate.
+        id: created[0].id,
+        voteId,
+        optionId,
+        weight: created.reduce((s, c) => s + c.weight, 0),
+        receiptHash: created[0].receiptHash,
+        castOnBehalf: !!castById,
+        ballots: created,
+        count: created.length,
+      },
+      { status: 201 }
+    );
   } catch (error) {
     console.error("Failed to cast ballot:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/voting/votes/[id]/route.ts
+++ b/src/app/api/voting/votes/[id]/route.ts
@@ -52,25 +52,20 @@ export async function GET(request: NextRequest, context: RouteContext) {
       ? await calculateMeetingQuorum(vote.meetingId)
       : null;
 
-    // Resolve user's unit in this building
-    const userUnit = await prisma.unitUser.findFirst({
-      where: { userId, unit: { buildingId } },
-      select: { unitId: true },
+    // The caller's own units in this building (only owners vote — Tht. §38).
+    // myWeight is the SUM across all owned units; a single cast fans out to each.
+    const ownerUnits = await prisma.unitUser.findMany({
+      where: { userId, relationship: "OWNER", unit: { buildingId } },
+      select: { unit: { select: { id: true, ownershipShare: true } } },
     });
+    const myWeight = ownerUnits.reduce((sum, u) => sum + Number(u.unit.ownershipShare), 0);
+    const ownerUnitIds = ownerUnits.map((u) => u.unit.id);
 
-    // Check if user's unit already voted
-    const myBallot = userUnit
-      ? await prisma.ballot.findUnique({
-          where: { voteId_unitId: { voteId: id, unitId: userUnit.unitId } },
+    // Whether the caller's units have voted (any of them) + which option.
+    const myBallot = ownerUnitIds.length
+      ? await prisma.ballot.findFirst({
+          where: { voteId: id, unitId: { in: ownerUnitIds } },
           select: { optionId: true, receiptHash: true },
-        })
-      : null;
-
-    // Get user's unit ownership share for display
-    const unit = userUnit
-      ? await prisma.unit.findUnique({
-          where: { id: userUnit.unitId },
-          select: { ownershipShare: true },
         })
       : null;
 
@@ -153,7 +148,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       myBallot: myBallot
         ? { optionId: myBallot.optionId, receiptHash: myBallot.receiptHash }
         : null,
-      myWeight: unit ? Number(unit.ownershipShare) : 0,
+      myWeight,
       proxyUnits,
       results,
       ballots: vote.ballots.map((b) => ({

--- a/tests/integration/ballot-multi-unit.test.ts
+++ b/tests/integration/ballot-multi-unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Multi-unit owners: a single self-cast fans out to one ballot per owned unit
+ * (same option), so the full ownership weight counts. Already-voted units are
+ * skipped; for a meeting vote only checked-in units are cast.
+ */
+const { ctxMock } = vi.hoisted(() => ({ ctxMock: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ requireBuildingContext: ctxMock, getCurrentUser: vi.fn(), auth: vi.fn() }));
+vi.mock("@/lib/feature-gate", () => ({
+  requireFeature: vi.fn().mockResolvedValue(undefined),
+  FeatureGateError: class FeatureGateError extends Error {},
+}));
+vi.mock("@/lib/rate-limit", () => ({ rateLimitMutationOrRespond: vi.fn().mockResolvedValue(null) }));
+
+const { POST: ballotPOST } = await import("@/app/api/voting/votes/[id]/ballot/route");
+const { GET: voteGET } = await import("@/app/api/voting/votes/[id]/route");
+
+beforeEach(() => ctxMock.mockReset());
+
+async function ownerWithUnits(shares: string[], opts: { meeting?: boolean } = {}) {
+  const { building } = await makeBuilding();
+  const owner = await makeUser({ buildingId: building.id, role: "OWNER" });
+  const units = [];
+  for (let i = 0; i < shares.length; i++) {
+    const u = await prisma.unit.create({
+      data: { number: `U${i}`, floor: 1, ownershipShare: shares[i], size: "50.00", buildingId: building.id },
+    });
+    await prisma.unitUser.create({ data: { userId: owner.id, unitId: u.id, relationship: "OWNER", isPrimaryContact: i === 0 } });
+    units.push(u);
+  }
+  const meeting = opts.meeting
+    ? await prisma.meeting.create({
+        data: { title: "M", date: new Date(), time: "18:00", buildingId: building.id, createdById: owner.id, liveStatus: "LIVE" },
+      })
+    : null;
+  const vote = await prisma.vote.create({
+    data: {
+      buildingId: building.id, title: "V", voteType: "YES_NO", majorityType: "SIMPLE_MAJORITY",
+      isSecret: false, status: "OPEN", quorumRequired: 0.5, deadline: new Date("2099-12-31"),
+      createdById: owner.id, meetingId: meeting?.id ?? null,
+    },
+  });
+  const option = await prisma.voteOption.create({ data: { voteId: vote.id, label: "Igen", sortOrder: 0 } });
+  return { building, owner, units, meeting, vote, option };
+}
+
+function asOwner(buildingId: string, userId: string) {
+  ctxMock.mockResolvedValue({ userId, buildingId, role: "OWNER", ownsAnyUnit: true, isProfessional: false, isChair: false, isAuditor: false });
+}
+const castReq = (optionId: string) => new NextRequest("http://test/x", { method: "POST", body: JSON.stringify({ optionId }) });
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("multi-unit self-cast fan-out", () => {
+  it("casts one ballot per owned unit and sums the weight", async () => {
+    const { building, owner, units, vote, option } = await ownerWithUnits(["0.3000", "0.2000"]);
+    asOwner(building.id, owner.id);
+
+    const res = await ballotPOST(castReq(option.id), params(vote.id));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.count).toBe(2);
+
+    const ballots = await prisma.ballot.findMany({ where: { voteId: vote.id } });
+    expect(ballots).toHaveLength(2);
+    expect(new Set(ballots.map((b) => b.unitId))).toEqual(new Set(units.map((u) => u.id)));
+    expect(ballots.every((b) => b.optionId === option.id)).toBe(true);
+
+    // GET reflects the summed weight.
+    const detail = await (await voteGET(new NextRequest("http://test/x"), params(vote.id))).json();
+    expect(detail.myWeight).toBeCloseTo(0.5, 5);
+    expect(detail.myBallot?.optionId).toBe(option.id);
+  });
+
+  it("skips units that already voted (idempotent re-cast)", async () => {
+    const { building, owner, units, vote, option } = await ownerWithUnits(["0.3000", "0.2000"]);
+    // One unit already has a ballot.
+    await prisma.ballot.create({ data: { voteId: vote.id, optionId: option.id, unitId: units[0].id, userId: owner.id, weight: "0.3000" } });
+    asOwner(building.id, owner.id);
+
+    const res = await ballotPOST(castReq(option.id), params(vote.id));
+    expect(res.status).toBe(201);
+    expect((await res.json()).count).toBe(1); // only the second unit
+    expect(await prisma.ballot.count({ where: { voteId: vote.id } })).toBe(2);
+  });
+
+  it("in a meeting, casts only for checked-in units", async () => {
+    const { building, owner, units, meeting, vote, option } = await ownerWithUnits(["0.3000", "0.2000"], { meeting: true });
+    // Only the first unit is checked in.
+    await prisma.meetingAttendance.create({ data: { meetingId: meeting!.id, unitId: units[0].id, checkedIn: true } });
+    asOwner(building.id, owner.id);
+
+    const res = await ballotPOST(castReq(option.id), params(vote.id));
+    expect(res.status).toBe(201);
+    expect((await res.json()).count).toBe(1);
+    const ballots = await prisma.ballot.findMany({ where: { voteId: vote.id } });
+    expect(ballots.map((b) => b.unitId)).toEqual([units[0].id]);
+  });
+});


### PR DESCRIPTION
Closes the **multi-unit-per-ballot** follow-up (the deferred item from the proxy work, #88).

## The bug
The voting UI already **summed** an owner's share across all their units (and flipped the "voted" state on the first ballot), but the cast only recorded **one** unit's ballot (`findFirst`). So a multi-unit owner's remaining ownership weight never counted — the displayed share didn't match what was recorded.

## Fix
- **Ballot endpoint** — the self-cast path resolves **all** the owner's units and fans out **one ballot per unit** (same option). Already-voted units are skipped (409 only if none remain); for a meeting vote, only **checked-in** units are cast (per-unit presence gate). Proxy / board-on-behalf stay single-target. Response gains `ballots[]` + `count`; back-compat fields kept (`weight` = sum, `receiptHash` = first) so existing callers — including the secret-ballot receipt in `active-vote-card` — are unaffected.
- **Vote-detail GET** — `myWeight` now sums all owned units; `myBallot` reflects any of them. The companion and main voting page show the full share and correct voted state. One tap covers all the owner's units.

## Model
A multi-unit owner's single choice **applies to all their units**. Proxies remain **per-unit** (a grantee may hold differing instructions) — shipped in #88. Splitting a vote across one's own units is intentionally not supported (rare; separate ask if ever needed).

## Verification
- New tests: fan-out (2 units → 2 ballots, summed weight), skip already-voted, meeting casts only checked-in units.
- **282 tests pass**; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)