### PR TITLE
feat(voting): "cast all units" shortcut for a multi-unit grantor's proxy

### DIFF
--- a/src/app/api/voting/votes/[id]/ballot/route.ts
+++ b/src/app/api/voting/votes/[id]/ballot/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     const { id: voteId } = await context.params;
     const body = await request.json();
-    const { optionId, proxyForUnitId, onBehalfOfUnitId } = body;
+    const { optionId, proxyForUnitId, proxyForGrantorId, onBehalfOfUnitId } = body;
 
     if (!optionId) {
       return NextResponse.json(
@@ -91,8 +91,34 @@ export async function POST(request: NextRequest, context: RouteContext) {
         select: { userId: true },
       });
       targets = [{ unitId: onBehalfOfUnitId, ballotUserId: vote.isSecret ? null : unitOwner?.userId ?? null }];
+    } else if (proxyForGrantorId) {
+      // Proxy voting — grantee casts for ALL of one grantor's owner-units in a
+      // single action (the grantor instructs one way for their whole holding).
+      const now = new Date();
+      const proxy = await prisma.proxyAssignment.findFirst({
+        where: {
+          granteeId: userId,
+          grantorId: proxyForGrantorId,
+          validFrom: { lte: now },
+          AND: [
+            { OR: [{ voteId: voteId }, { voteId: null }] },
+            { OR: [{ validUntil: null }, { validUntil: { gte: now } }] },
+          ],
+        },
+      });
+      if (!proxy) {
+        return NextResponse.json({ error: "No valid proxy assignment found" }, { status: 403 });
+      }
+      const grantorUnits = await prisma.unitUser.findMany({
+        where: { userId: proxyForGrantorId, relationship: "OWNER", unit: { buildingId } },
+        select: { unitId: true },
+      });
+      if (grantorUnits.length === 0) {
+        return NextResponse.json({ error: "No unit found in this building" }, { status: 400 });
+      }
+      targets = grantorUnits.map((u) => ({ unitId: u.unitId, ballotUserId: vote.isSecret ? null : userId }));
     } else if (proxyForUnitId) {
-      // Proxy voting — grantee casts for the grantor's unit.
+      // Proxy voting — grantee casts for a single grantor unit.
       const userUnit = await prisma.unitUser.findFirst({
         where: { userId, unit: { buildingId } },
         select: { unitId: true },
@@ -206,7 +232,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       newValue: {
         voteId,
         unitIds: created.map((c) => c.unitId),
-        isProxy: !!proxyForUnitId,
+        isProxy: !!proxyForUnitId || !!proxyForGrantorId,
         isOnBehalf: !!onBehalfOfUnitId,
         isSecret: vote.isSecret,
       },

--- a/src/app/api/voting/votes/[id]/route.ts
+++ b/src/app/api/voting/votes/[id]/route.ts
@@ -83,6 +83,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         ],
       },
       select: {
+        grantorId: true,
         grantor: {
           select: {
             name: true,
@@ -97,7 +98,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const proxyUnitMap = new Map<
       string,
-      { unitId: string; unitNumber: string; grantorName: string; weight: number }
+      { unitId: string; unitNumber: string; grantorId: string; grantorName: string; weight: number }
     >();
     for (const pa of proxyAssignments) {
       for (const uu of pa.grantor.unitUsers) {
@@ -105,6 +106,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
           proxyUnitMap.set(uu.unit.id, {
             unitId: uu.unit.id,
             unitNumber: uu.unit.number,
+            grantorId: pa.grantorId,
             grantorName: pa.grantor.name,
             weight: Number(uu.unit.ownershipShare),
           });

--- a/src/components/voting/assembly-companion.tsx
+++ b/src/components/voting/assembly-companion.tsx
@@ -29,6 +29,7 @@ function parseAgenda(raw: unknown): AgendaItem[] {
 interface ProxyUnit {
   unitId: string;
   unitNumber: string;
+  grantorId: string;
   grantorName: string;
   weight: number;
   votedOptionId: string | null;
@@ -145,16 +146,17 @@ export function AssemblyCompanion({
     }
   }
 
-  // Cast on behalf of a unit the user holds a proxy (meghatalmazás) for.
-  async function castProxy(unitId: string) {
-    const optionId = proxyPicked[unitId];
+  // Cast on behalf of all units the user holds a proxy (meghatalmazás) for from
+  // one grantor — a single grantor instructs one way for their whole holding.
+  async function castProxyGrantor(grantorId: string) {
+    const optionId = proxyPicked[grantorId];
     if (!optionId || !voteId || proxyBusy) return;
-    setProxyBusy(unitId);
+    setProxyBusy(grantorId);
     try {
       const res = await fetch(`/api/voting/votes/${voteId}/ballot`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ optionId, proxyForUnitId: unitId }),
+        body: JSON.stringify({ optionId, proxyForGrantorId: grantorId }),
       });
       if (!res.ok) {
         const d = await res.json().catch(() => ({}));
@@ -272,24 +274,39 @@ export function AssemblyCompanion({
             <div className="font-mono text-[10.5px] uppercase tracking-wider mb-3" style={{ color: "var(--color-muted)" }}>
               {t("companionProxyTitle")}
             </div>
-            {detail.proxyUnits.map((pu) => {
-              const voted = detail.options.find((o) => o.id === pu.votedOptionId);
+            {Object.values(
+              detail.proxyUnits.reduce(
+                (acc, pu) => {
+                  (acc[pu.grantorId] ??= { grantorId: pu.grantorId, grantorName: pu.grantorName, units: [] }).units.push(pu);
+                  return acc;
+                },
+                {} as Record<string, { grantorId: string; grantorName: string; units: ProxyUnit[] }>,
+              ),
+            ).map((g) => {
+              const totalWeight = g.units.reduce((s, u) => s + u.weight, 0);
+              const pending = g.units.filter((u) => !u.votedOptionId);
+              const allVoted = pending.length === 0;
+              const votedFirst = g.units.find((u) => u.votedOptionId);
+              const votedOpt = votedFirst ? detail.options.find((o) => o.id === votedFirst.votedOptionId) : undefined;
               return (
-                <div key={pu.unitId} className="mb-3.5 pb-3.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--color-ink) 7%, transparent)" }}>
+                <div key={g.grantorId} className="mb-3.5 pb-3.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--color-ink) 7%, transparent)" }}>
                   <div className="text-[13px] font-semibold mb-2">
-                    {pu.grantorName} <span className="font-mono text-[11px] font-normal" style={{ color: "var(--color-muted)" }}>· {pu.unitNumber} · {(pu.weight * 100).toFixed(2)}%</span>
+                    {g.grantorName}{" "}
+                    <span className="font-mono text-[11px] font-normal" style={{ color: "var(--color-muted)" }}>
+                      · {g.units.length === 1 ? g.units[0].unitNumber : t("companionProxyUnitCount", { n: g.units.length })} · {(totalWeight * 100).toFixed(2)}%
+                    </span>
                   </div>
-                  {voted ? (
+                  {allVoted ? (
                     <div className="flex items-center gap-2 rounded-lg px-3 py-2 text-[13px] font-semibold" style={{ background: "color-mix(in srgb, var(--color-moss) 14%, transparent)", color: "var(--color-moss)" }}>
-                      ✓ {t("companionVoted", { label: voted.label })}
+                      ✓ {t("companionVoted", { label: votedOpt?.label ?? "" })}
                     </div>
                   ) : (
                     <>
                       <div className="flex flex-wrap gap-1.5 mb-2">
                         {detail.options.map((o) => {
-                          const sel = proxyPicked[pu.unitId] === o.id;
+                          const sel = proxyPicked[g.grantorId] === o.id;
                           return (
-                            <button key={o.id} onClick={() => setProxyPicked((p) => ({ ...p, [pu.unitId]: o.id }))}
+                            <button key={o.id} onClick={() => setProxyPicked((p) => ({ ...p, [g.grantorId]: o.id }))}
                               className="rounded-lg px-3 py-2 text-[13px] font-semibold"
                               style={{
                                 border: `1.5px solid ${sel ? "var(--color-ink)" : "color-mix(in srgb, var(--color-ink) 14%, transparent)"}`,
@@ -300,10 +317,12 @@ export function AssemblyCompanion({
                           );
                         })}
                       </div>
-                      <button onClick={() => castProxy(pu.unitId)} disabled={!proxyPicked[pu.unitId] || proxyBusy === pu.unitId}
+                      <button onClick={() => castProxyGrantor(g.grantorId)} disabled={!proxyPicked[g.grantorId] || proxyBusy === g.grantorId}
                         className="w-full rounded-lg py-2.5 text-[13px] font-bold disabled:opacity-50"
                         style={{ background: "var(--color-ink)", color: "var(--color-bg)" }}>
-                        {t("companionProxyCast", { name: pu.grantorName })}
+                        {g.units.length > 1
+                          ? t("companionProxyCastAll", { name: g.grantorName, n: pending.length })
+                          : t("companionProxyCast", { name: g.grantorName })}
                       </button>
                     </>
                   )}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2100,6 +2100,8 @@
     "companionVoted": "Vote recorded · {label}",
     "companionProxyTitle": "By proxy",
     "companionProxyCast": "Cast for {name}",
+    "companionProxyCastAll": "Cast for {name} ({n} units)",
+    "companionProxyUnitCount": "{n} units",
     "castVote": "Cast vote",
     "companionTallyHidden": "The result is hidden until close.",
     "companionAsk": "Question",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2100,6 +2100,8 @@
     "companionVoted": "Szavazata rögzítve · {label}",
     "companionProxyTitle": "Meghatalmazással",
     "companionProxyCast": "Leadom {name} nevében",
+    "companionProxyCastAll": "Leadom {name} nevében ({n} albetét)",
+    "companionProxyUnitCount": "{n} albetét",
     "castVote": "Szavazat leadása",
     "companionTallyHidden": "Az eredmény a lezárásig rejtett.",
     "companionAsk": "Kérdés",

--- a/tests/integration/assembly-proxy-voting.test.ts
+++ b/tests/integration/assembly-proxy-voting.test.ts
@@ -80,4 +80,32 @@ describe("proxy voting", () => {
     const after = await (await voteGET(new NextRequest("http://test/x"), params(vote.id))).json();
     expect(after.proxyUnits[0].votedOptionId).toBe(option.id);
   });
+
+  it("casts for ALL of a grantor's units via proxyForGrantorId", async () => {
+    const { building, grantor, grantee, grantorUnit, vote, option } = await scenario();
+    // Give the grantor a second owned unit in the building.
+    const grantorUnit2 = await prisma.unit.create({
+      data: { number: "2b", floor: 2, ownershipShare: "0.1500", size: "40.00", buildingId: building.id },
+    });
+    await prisma.unitUser.create({
+      data: { userId: grantor.id, unitId: grantorUnit2.id, relationship: "OWNER", isPrimaryContact: false },
+    });
+    asGrantee(building.id, grantee.id);
+
+    // Both of the grantor's units surface as proxied.
+    const detail = await (await voteGET(new NextRequest("http://test/x"), params(vote.id))).json();
+    expect(detail.proxyUnits).toHaveLength(2);
+    expect(detail.proxyUnits.every((u: { grantorId: string }) => u.grantorId === grantor.id)).toBe(true);
+
+    // One action casts for the grantor's whole holding.
+    const res = await ballotPOST(
+      new NextRequest("http://test/x", { method: "POST", body: JSON.stringify({ optionId: option.id, proxyForGrantorId: grantor.id }) }),
+      params(vote.id),
+    );
+    expect(res.status).toBe(201);
+    expect((await res.json()).count).toBe(2);
+
+    const ballots = await prisma.ballot.findMany({ where: { voteId: vote.id } });
+    expect(new Set(ballots.map((b) => b.unitId))).toEqual(new Set([grantorUnit.id, grantorUnit2.id]));
+  });
 });


### PR DESCRIPTION
The optional proxy nicety from the last discussion. Follow-up to #88: a grantee holding a proxy from an owner of **several** units had to cast each unit separately. Now one action covers that grantor's whole holding.

## Change
- **Ballot endpoint** — new `proxyForGrantorId`: validates the caller holds a valid (in-scope, in-window) proxy from that grantor, then **fans out one ballot per the grantor's owner-unit** (reuses the multi-target machinery; already-voted units skipped). Single-unit `proxyForUnitId` still supported.
- **Vote-detail GET** — `proxyUnits` now carry `grantorId` so the client can group.
- **Companion** — the "Meghatalmazással" section is grouped **by grantor**: one row per grantor (units + total share), a single option picker, and a **"Leadom {név} nevében ({n} albetét)"** button casting for all their pending units. Different grantors remain separate groups, so differing instructions are preserved. i18n (hu+en).

## Verification
- Test: `proxyForGrantorId` casts for all of a grantor's units (2 → 2 ballots); the existing single-unit proxy path is unchanged.
- **283 tests pass**; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)