### PR TITLE
fix(nav): repair dead-end links + Teendőim page + missing i18n keys

### DIFF
--- a/src/app/[locale]/dashboard/tasks/page.tsx
+++ b/src/app/[locale]/dashboard/tasks/page.tsx
@@ -1,0 +1,88 @@
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getFollowups, type FollowupItem } from "@/lib/dashboard-dal";
+
+type Props = { params: Promise<{ locale: string }> };
+
+const PILL: Record<FollowupItem["pill"], { bg: string; fg: string }> = {
+  due: { bg: "color-mix(in srgb, var(--color-danger) 14%, transparent)", fg: "var(--color-danger)" },
+  soon: { bg: "color-mix(in srgb, var(--color-ochre) 18%, transparent)", fg: "var(--color-ochre)" },
+  ok: { bg: "color-mix(in srgb, var(--color-moss) 14%, transparent)", fg: "var(--color-moss)" },
+  neutral: { bg: "var(--color-bg-3)", fg: "var(--color-muted)" },
+};
+
+/**
+ * "Teendőim" — the full follow-up list (the dashboard panel shows a preview).
+ * Reuses getFollowups(): Task rows UNIONed with derived signals (overdue
+ * charges, unassigned tickets, meetings needing minutes). Read-only; each row
+ * links to the module it came from.
+ */
+export default async function TasksPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const [t, tc] = await Promise.all([getTranslations("dashboard"), getTranslations("common")]);
+  let followups: FollowupItem[] = [];
+  try {
+    followups = await getFollowups();
+  } catch {
+    followups = [];
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-5 py-8">
+      <Link
+        href={`/${locale}/dashboard`}
+        className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wider text-muted hover:text-ink transition-colors"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {tc("back")}
+      </Link>
+
+      <h1 className="font-display text-2xl text-ink mt-4 mb-1" style={{ letterSpacing: "-0.02em" }}>
+        {t("myTasks")}
+      </h1>
+      <p className="font-mono text-[11px] text-muted mb-6">
+        {followups.length > 0 ? `${followups.length} ${t("openItems")}` : ""}
+      </p>
+
+      {followups.length === 0 ? (
+        <p className="text-sm text-muted">{t("emptyTasks")}</p>
+      ) : (
+        <ul className="space-y-2">
+          {followups.map((f) => {
+            const pill = PILL[f.pill];
+            const inner = (
+              <div
+                className="flex items-center justify-between gap-3 rounded-xl border border-ink/8 bg-card px-4 py-3 transition-colors hover:border-ink/20"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-ink">{f.title}</p>
+                  <p className="truncate font-mono text-[11px] text-muted">{f.meta}</p>
+                </div>
+                <span
+                  className="shrink-0 rounded-full px-2.5 py-0.5 font-mono text-[10.5px] font-semibold uppercase tracking-wider"
+                  style={{ background: pill.bg, color: pill.fg }}
+                >
+                  {f.pillText}
+                </span>
+              </div>
+            );
+            return (
+              <li key={f.id}>
+                {f.href ? (
+                  <Link href={`/${locale}${f.href}`} className="block">
+                    {inner}
+                  </Link>
+                ) : (
+                  inner
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -169,7 +169,7 @@ export default async function ProfilePage({ params }: Props) {
               detail={t("security.passwordDetail")}
               right={
                 <Link
-                  href={`/${locale}/settings/password`}
+                  href={`/${locale}/forgot-password`}
                   style={{
                     fontSize: "12px",
                     fontWeight: 600,

--- a/src/components/compliance/audit-committee-required-banner.tsx
+++ b/src/components/compliance/audit-committee-required-banner.tsx
@@ -69,7 +69,7 @@ export function AuditCommitteeRequiredBanner({
         </p>
       </div>
       <Link
-        href={`/${locale}/settings/building-officers#fb`}
+        href={`/${locale}/admin/officer-registry`}
         className="inline-flex min-h-11 items-center self-start rounded-md px-4 font-mono text-[11px] uppercase tracking-wider sm:min-h-0 sm:self-auto"
         style={{
           background: "var(--color-ink)",

--- a/src/components/dashboard/admin-dashboard.tsx
+++ b/src/components/dashboard/admin-dashboard.tsx
@@ -129,7 +129,7 @@ export function AdminDashboard({ initialData, userName }: AdminDashboardProps) {
               <QuickAction
                 icon={<Megaphone className="h-4 w-4" />}
                 label={t("createAnnouncement")}
-                href="/announcements"
+                href="/communication"
               />
               <QuickAction
                 icon={<CreditCard className="h-4 w-4" />}

--- a/src/components/dashboard/board-dashboard.tsx
+++ b/src/components/dashboard/board-dashboard.tsx
@@ -204,21 +204,6 @@ export async function BoardDashboard({
             <CalendarIcon />
             {now.toLocaleDateString(intlLocale(locale), { month: "long" })}
           </button>
-          <Link
-            href={`/${locale}/dashboard/tasks/new`}
-            className="inline-flex items-center gap-2 transition-opacity hover:opacity-90"
-            style={{
-              padding: "9px 14px",
-              borderRadius: "8px",
-              fontSize: "13px",
-              fontWeight: 600,
-              background: "var(--color-ink)",
-              color: "var(--color-bg)",
-            }}
-          >
-            <PlusIcon />
-            {t("newTask")}
-          </Link>
         </div>
       </div>
 
@@ -312,7 +297,7 @@ export async function BoardDashboard({
       {/* ── Quick actions ──────────────────────────────────────────────── */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3" style={{ marginBottom: "24px" }}>
         <QuickAction
-          href={`/${locale}/announcements/new`}
+          href={`/${locale}/communication`}
           iconBg="var(--color-ink)"
           iconColor="var(--color-bg)"
           label={t("quickAnnouncement")}
@@ -388,7 +373,7 @@ export async function BoardDashboard({
             sub={data.activeVote ? `VOTE-${data.activeVote.id.slice(-6).toUpperCase()}` : "—"}
             link={
               data.activeVote
-                ? { label: t("open"), href: `/${locale}/voting/${data.activeVote.id}` }
+                ? { label: t("open"), href: `/${locale}/voting` }
                 : undefined
             }
           />
@@ -593,7 +578,7 @@ export async function BoardDashboard({
           <PanelHead
             title={t("boardMembers")}
             sub={`${data.boardMembers.length} ${t("boardMembersSub")}`}
-            link={{ label: t("message"), href: `/${locale}/messages` }}
+            link={{ label: t("message"), href: `/${locale}/communication` }}
           />
           <div style={{ padding: "22px" }}>
             {data.boardMembers.length === 0 ? (

--- a/src/components/dashboard/member-dashboard.tsx
+++ b/src/components/dashboard/member-dashboard.tsx
@@ -189,7 +189,7 @@ export async function MemberDashboard({ locale, userName, data }: Props) {
           icon="wrench"
         />
         <QuickAction
-          href={`/${locale}/messages`}
+          href={`/${locale}/communication`}
           iconBg="var(--color-ink)"
           iconColor="var(--color-bg)"
           label={t("memberQuickMessageChair")}
@@ -228,7 +228,7 @@ export async function MemberDashboard({ locale, userName, data }: Props) {
         )}
         {isTenant && (
           <QuickAction
-            href={`/${locale}/announcements`}
+            href={`/${locale}/communication`}
             iconBg="color-mix(in srgb, var(--color-ink) 90%, var(--color-moss))"
             iconColor="var(--color-bg)"
             label={t("memberQuickAnnouncements")}
@@ -254,7 +254,7 @@ export async function MemberDashboard({ locale, userName, data }: Props) {
                 ? `${unreadCount} ${t("memberAnnouncementsUnread")}`
                 : t("memberAnnouncementsAllRead")
             }
-            link={{ label: t("seeAll"), href: `/${locale}/announcements` }}
+            link={{ label: t("seeAll"), href: `/${locale}/communication` }}
           />
           <div>
             {data.announcements.length === 0 ? (
@@ -278,7 +278,7 @@ export async function MemberDashboard({ locale, userName, data }: Props) {
               }
               link={{
                 label: data.activeVote.hasCast ? t("open") : t("memberCastVote"),
-                href: `/${locale}/voting/${data.activeVote.id}`,
+                href: `/${locale}/voting`,
               }}
             />
             <div style={{ padding: "22px" }}>
@@ -317,7 +317,7 @@ export async function MemberDashboard({ locale, userName, data }: Props) {
                 {t("voteClosesPrefix")} · {formatDateShort(data.activeVote.deadline, locale)}
               </div>
               <Link
-                href={`/${locale}/voting/${data.activeVote.id}`}
+                href={`/${locale}/voting`}
                 className="inline-flex items-center gap-2 transition-opacity hover:opacity-90"
                 style={{
                   padding: "10px 16px",
@@ -353,7 +353,7 @@ export async function MemberDashboard({ locale, userName, data }: Props) {
             <div style={{ padding: "22px" }}>
               {data.houseRulesDoc ? (
                 <Link
-                  href={`/${locale}/documents/${data.houseRulesDoc.id}`}
+                  href={`/${locale}/documents`}
                   className="flex items-center gap-3 transition-colors hover:bg-[var(--color-bg-3)]"
                   style={{
                     padding: "16px",
@@ -459,7 +459,7 @@ export async function MemberDashboard({ locale, userName, data }: Props) {
           <div style={{ padding: "22px" }}>
             {data.chair ? (
               <Link
-                href={`/${locale}/messages?to=${data.chair.id}`}
+                href={`/${locale}/communication`}
                 className="flex items-center gap-3 transition-colors hover:bg-[var(--color-bg-3)]"
                 style={{
                   padding: "14px",
@@ -725,7 +725,7 @@ function AnnouncementRow({
 }) {
   return (
     <Link
-      href={`/${locale}/announcements/${item.id}`}
+      href={`/${locale}/communication`}
       className="grid items-start cursor-pointer hover:bg-[var(--color-bg-3)] transition-colors"
       style={{
         gridTemplateColumns: "8px 1fr auto",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,6 +1,9 @@
 {
   "common": {
     "appName": "Condo Manager",
+    "back": "Back",
+    "done": "Done",
+    "notifications": "Notifications",
     "tenantConsentLabel": "Tenant has provided explicit consent to retain email and phone for building communication (GDPR Art. 6, Tht. § 22(2)). Without consent the building may store only name and unit presence.",
     "login": "Log in",
     "logout": "Log out",
@@ -1965,6 +1968,8 @@
       "downloaded": "Downloaded",
       "lastAccess": "Last access",
       "pinCta": "Pin",
+      "pinned": "Pinned",
+      "unpinned": "Unpinned",
       "unpinCta": "Unpin"
     },
     "modal": {
@@ -2880,6 +2885,7 @@
     "legacyPlan": "Legacy Plan",
     "legacyDescription": "This is a legacy subscription with all features enabled.",
     "noStripeSubscription": "No Stripe subscription linked",
+    "noSubscription": "No active subscription.",
     "frozenBanner": "You have {count} buildings over your plan limit. Remove buildings or upgrade to restore full access.",
     "frozenBuildingBadge": "Frozen",
     "overLimit": "Over limit",
@@ -3055,6 +3061,8 @@
   },
   "landing": {
     "startFreeTrial": "Start Free Trial",
+    "footerCopyright": "© 2026 Közös Kft. · All rights reserved.",
+    "footerLogin": "Log in",
     "viewPricing": "View Pricing",
     "goToDashboard": "Go to Dashboard",
     "hero": {

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -1,6 +1,9 @@
 {
   "common": {
     "appName": "Társasházkezelő",
+    "back": "Vissza",
+    "done": "Kész",
+    "notifications": "Értesítések",
     "tenantConsentLabel": "A bérlő kifejezett hozzájárulását adta, hogy a társasház a kommunikációhoz tárolja az e-mail-címét és telefonszámát (GDPR 6. cikk, Tht. 22. § (2)). Hozzájárulás hiányában csak a név és az albetét-jelenlét tárolható.",
     "login": "Bejelentkezés",
     "logout": "Kijelentkezés",
@@ -1965,6 +1968,8 @@
       "downloaded": "Letöltve",
       "lastAccess": "Utolsó hozzáférés",
       "pinCta": "Kitűz",
+      "pinned": "Rögzítve",
+      "unpinned": "Rögzítés feloldva",
       "unpinCta": "Levesz"
     },
     "modal": {
@@ -2880,6 +2885,7 @@
     "legacyPlan": "Legacy csomag",
     "legacyDescription": "Ez egy legacy elofizetes, minden funkcio elerheto.",
     "noStripeSubscription": "Nincs Stripe elofizetes csatolva",
+    "noSubscription": "Nincs aktív előfizetés.",
     "frozenBanner": "{count} epulet meghaladja a csomag korlatjat. Tavolitson el epuleteket vagy frissitsen a teljes hozzaferes visszaallitasahoz.",
     "frozenBuildingBadge": "Befagyasztva",
     "overLimit": "Korlat felett",
@@ -3055,6 +3061,8 @@
   },
   "landing": {
     "startFreeTrial": "Próbáld ki ingyen",
+    "footerCopyright": "© 2026 Közös Kft. · Minden jog fenntartva.",
+    "footerLogin": "Bejelentkezés",
     "viewPricing": "Árak megtekintése",
     "goToDashboard": "Irányítópult",
     "hero": {


### PR DESCRIPTION
Output of the "massive discovery" audit. Four parallel auditors swept the app for dead ends; this PR fixes the confirmed ones (all 404s verified live on prod).

## Dead navigation → re-pointed to the real feature
Prominent CTAs (mostly dashboard-level) that hit nonexistent routes:
- **announcements** (member/board/admin dashboards, 5 links) → `/communication`
- **messages** (member ×2, board ×1) → `/communication`
- **`/voting/{voteId}`** (member, board active-vote CTA) → `/voting` (the cast page)
- **`/documents/{id}`** (house-rules link) → `/documents`
- **`/settings/building-officers`** (compliance banner) → `/admin/officer-registry`
- **`/settings/password`** (security CTA) → `/forgot-password`

## Tasks (no route, no backend)
- **`/dashboard/tasks`** ("see all") now resolves — added a **Teendőim** page listing the full `getFollowups()` set (the dashboard only previewed it).
- **`/dashboard/tasks/new`** (create) **removed** — there's no task-create flow; followups are derived signals, not user-created rows.

## Missing i18n keys (rendered as raw keys, both locales)
`common.back`, `common.done`, `common.notifications`, `documents.panel.pinned`/`.unpinned`, `landing.footerCopyright`/`.footerLogin`, `billing.noSubscription`.

## Deliberately NOT touched (need real content)
The `href="#"` **Terms / Privacy / Help / DPA** links in the auth + footer flows — there are no legal routes and I won't invent legal copy. Flagged for a real legal-pages task.

## Also from the audit (no code change)
- **API calls: clean** — all 159 `fetch`es map to existing routes + correct methods.
- **"Hamarosan" stubs** (Bank CSV / PDF report / Invoices tab / Units CSV / Maintenance map view / OAuth buttons / unit-detail edit) are *intentional* unfinished features, inventoried but left as-is.

## Verification
- 283 tests pass; tsc + lint clean. Re-pointed routes confirmed to exist; will live-verify on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)