### PR TITLE
feat(onboarding): 100% ownership-share gate on units import (SZMSZ P1)

### DIFF
--- a/src/app/actions/units.ts
+++ b/src/app/actions/units.ts
@@ -282,12 +282,17 @@ export async function importUnits(rows: ImportRow[]): Promise<ImportResultType> 
       };
     }
 
-    // Get existing unit numbers
+    // Get existing unit numbers + the ownership-share total already on file
+    // (needed for the 100%-share gate below).
     const existingUnits = await prisma.unit.findMany({
       where: { buildingId },
-      select: { number: true },
+      select: { number: true, ownershipShare: true },
     });
     const existingNumbers = new Set(existingUnits.map((u) => u.number));
+    const existingShareSum = existingUnits.reduce(
+      (sum, u) => sum + Number(u.ownershipShare),
+      0,
+    );
 
     const errors: { row: number; message: string }[] = [];
     const validData: { number: string; floor: number; size: number; ownershipShare: number }[] = [];
@@ -323,6 +328,26 @@ export async function importUnits(rows: ImportRow[]): Promise<ImportResultType> 
       return { created: 0, skipped: rows.length - errors.length, errors };
     }
 
+    // 100%-share gate (Tht. §43: ownership shares are the legal basis for voting
+    // weight + cost allocation). The building total can never exceed 1.0; reject
+    // the whole import if it would (a sign of bad data). Falling short of 100% is
+    // allowed — onboarding may import in batches — but reported as incomplete.
+    const importedShareSum = validData.reduce((s, d) => s + d.ownershipShare, 0);
+    const buildingShareTotal = existingShareSum + importedShareSum;
+    const SHARE_EPS = 0.0001;
+    if (buildingShareTotal > 1 + SHARE_EPS) {
+      return {
+        created: 0,
+        skipped: rows.length,
+        errors: [
+          {
+            row: 0,
+            message: `Total ownership share would exceed 100% (existing ${(existingShareSum * 100).toFixed(2)}% + import ${(importedShareSum * 100).toFixed(2)}% = ${(buildingShareTotal * 100).toFixed(2)}%). Check the shares.`,
+          },
+        ],
+      };
+    }
+
     // Batch create
     const created = await prisma.unit.createMany({
       data: validData.map((d) => ({
@@ -355,7 +380,10 @@ export async function importUnits(rows: ImportRow[]): Promise<ImportResultType> 
       skipped: rows.length - validData.length - errors.length,
       errors,
       summary: {
-        totalOwnershipImported: validData.reduce((sum, d) => sum + d.ownershipShare, 0).toFixed(4),
+        totalOwnershipImported: importedShareSum.toFixed(4),
+        buildingShareTotal: buildingShareTotal.toFixed(4),
+        /** True once the building's units sum to 100% — drives the onboarding checklist. */
+        sharesComplete: Math.abs(buildingShareTotal - 1) <= SHARE_EPS,
       },
     };
   } catch (error) {

--- a/tests/integration/units-import-shares.test.ts
+++ b/tests/integration/units-import-shares.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { makeBuilding } from "../fixtures";
+import type { ImportRow } from "@/lib/import/types";
+
+/**
+ * Onboarding 100%-share gate: a units import is rejected if the building's
+ * ownership shares would exceed 100% (existing + imported); under 100% commits
+ * but reports incomplete; exactly 100% reports complete.
+ */
+const { ctxMock } = vi.hoisted(() => ({ ctxMock: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ requireBuildingContext: ctxMock, getCurrentUser: vi.fn(), auth: vi.fn() }));
+vi.mock("@/lib/authz", () => ({ requireCapability: vi.fn(), allows: vi.fn(() => true) }));
+vi.mock("@/lib/frozen-check", () => ({ requireNotFrozen: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/plan-limits", () => ({ checkUnitLimit: vi.fn().mockResolvedValue({ allowed: true, current: 0, max: -1 }) }));
+vi.mock("@/lib/audit", () => ({ createAuditLog: vi.fn().mockResolvedValue(undefined) }));
+
+const { importUnits } = await import("@/app/actions/units");
+
+beforeEach(() => ctxMock.mockReset());
+
+function rows(specs: [string, string][]): ImportRow[] {
+  // [unit_number, ownership_share]
+  return specs.map(([n, s]) => ({ unit_number: n, floor: "1", size_sqm: "50", ownership_share: s }));
+}
+
+async function buildingCtx() {
+  const { building } = await makeBuilding();
+  ctxMock.mockResolvedValue({ userId: "u1", buildingId: building.id, role: "ADMIN", ownsAnyUnit: false });
+  return building;
+}
+
+describe("units import — 100% share gate", () => {
+  it("rejects an import that would exceed 100%", async () => {
+    await buildingCtx();
+    const res = await importUnits(rows([["A", "0.6"], ["B", "0.5"]])); // 110%
+    expect(res.created).toBe(0);
+    expect(res.errors[0].message).toMatch(/exceed 100%/i);
+    expect(await prisma.unit.count()).toBe(0);
+  });
+
+  it("commits a full 100% import and flags it complete", async () => {
+    await buildingCtx();
+    const res = await importUnits(rows([["A", "0.5000"], ["B", "0.5000"]]));
+    expect(res.created).toBe(2);
+    expect(res.summary?.buildingShareTotal).toBe("1.0000");
+    expect(res.summary?.sharesComplete).toBe(true);
+  });
+
+  it("allows a partial import but flags it incomplete", async () => {
+    await buildingCtx();
+    const res = await importUnits(rows([["A", "0.4000"]]));
+    expect(res.created).toBe(1);
+    expect(res.summary?.sharesComplete).toBe(false);
+  });
+
+  it("counts existing units toward the cap (second batch overshoots)", async () => {
+    const building = await buildingCtx();
+    await prisma.unit.create({
+      data: { number: "X", floor: 1, size: new Prisma.Decimal(50), ownershipShare: new Prisma.Decimal("0.7000"), buildingId: building.id },
+    });
+    const res = await importUnits(rows([["A", "0.4000"]])); // 0.7 + 0.4 = 110%
+    expect(res.created).toBe(0);
+    expect(res.errors[0].message).toMatch(/exceed 100%/i);
+  });
+});


### PR DESCRIPTION
First slice of the building-onboarding / SZMSZ migration tool (spreadsheet-first, full wizard to follow).

## Why
The units spreadsheet import validated each share 0–1 but never checked the **building total**. Ownership shares (tulajdoni hányad) are the legal basis for voting weight + cost allocation (Tht. §43), so they must sum to exactly **100%**. This adds that gate — the legal-correctness core of an SZMSZ migration.

## Change (`importUnits`)
- Sums existing units' shares + the imported shares; **rejects the whole import** (no rows written) if the building total would exceed 100% — a clear bad-data signal. Falling short is allowed (onboarding may import in batches) but reported as incomplete.
- Returns `summary.buildingShareTotal` + `summary.sharesComplete` for the onboarding checklist (later phase) to consume.

## Tests
Overshoot rejected (single import; and existing-units + batch); full 100% commits & flags complete; partial commits & flags incomplete. **291 tests pass**, tsc + lint clean.

## Roadmap (per the saved plan)
P2+: SZMSZ doc category + governance fields → onboarding **wizard** (building → SZMSZ upload → units review/commit → governance → owner invites) → per-building **setup checklist**. AI PDF extraction is a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)