### PR TITLE
feat(onboarding): surface units import + ownership-share KPI (SZMSZ P3.1)

### DIFF
--- a/src/components/units/units-header-actions.tsx
+++ b/src/components/units/units-header-actions.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { UnitModal } from "./unit-modal";
+import { ImportUnitsButton } from "./import-units-button";
 
 interface Props {
   isBoardPlus: boolean;
@@ -18,6 +19,7 @@ export function UnitsHeaderActions({ isBoardPlus }: Props) {
 
   return (
     <>
+      <ImportUnitsButton />
       <button
         type="button"
         onClick={() => {

--- a/src/components/units/units-kpis.tsx
+++ b/src/components/units/units-kpis.tsx
@@ -15,10 +15,12 @@ export async function UnitsKpiStrip({ locale, kpis }: Props) {
     kpis.total > 0 ? Math.round((kpis.tenantOccupied / kpis.total) * 100) : 0;
   const vacantPct =
     kpis.total > 0 ? Math.round((kpis.vacant / kpis.total) * 100) : 0;
+  const sharePct = kpis.ownershipShareTotal * 100;
+  const sharesComplete = Math.abs(kpis.ownershipShareTotal - 1) <= 0.0001;
 
   return (
     <div
-      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5"
+      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6"
       style={{ gap: "12px", marginBottom: "24px" }}
     >
       <Tile label={t("total")} value={kpis.total.toString()} />
@@ -43,6 +45,12 @@ export async function UnitsKpiStrip({ locale, kpis }: Props) {
         value={Math.round(kpis.totalAreaM2).toLocaleString("hu-HU")}
         unit="m²"
         accent="ink"
+      />
+      <Tile
+        label={t("ownershipShare")}
+        value={`${sharePct.toLocaleString("hu-HU", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`}
+        unit={sharesComplete ? "· 100%" : `· cél 100%`}
+        accent={sharesComplete ? "moss" : undefined}
       />
     </div>
   );

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -268,7 +268,8 @@
       "ownerOccupied": "Owner-occupied",
       "tenant": "Tenant-occupied",
       "vacant": "Vacant",
-      "totalArea": "Net area"
+      "totalArea": "Net area",
+      "ownershipShare": "Ownership share"
     },
     "tab": {
       "map": "Building map",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -268,7 +268,8 @@
       "ownerOccupied": "Tulajdonos lakik",
       "tenant": "Bérlős",
       "vacant": "Üres",
-      "totalArea": "Össz. hasznos ter."
+      "totalArea": "Össz. hasznos ter.",
+      "ownershipShare": "Tulajdoni hányad"
     },
     "tab": {
       "map": "Ház térkép",

--- a/src/lib/units-dal.ts
+++ b/src/lib/units-dal.ts
@@ -35,6 +35,8 @@ export interface UnitsKpis {
   tenantOccupied: number;
   vacant: number;
   totalAreaM2: number;
+  /** Sum of all units' ownership shares, 0..1 (should reach 1.0 — Tht. §43). */
+  ownershipShareTotal: number;
 }
 
 export interface UnitsFloorMap {
@@ -220,6 +222,7 @@ export const getUnitsOverview = cache(
       ).length,
       vacant: cells.filter((c) => c.occupancy === "vacant").length,
       totalAreaM2: cells.reduce((sum, c) => sum + c.size, 0),
+      ownershipShareTotal: cells.reduce((sum, c) => sum + c.ownershipShare, 0),
     };
 
     // ── Floor map (group by stairwell, floors descending) ────────────────


### PR DESCRIPTION
First UI slice of the onboarding tool — and it fixes a real orphan found while validating P1.

## The orphan
The units spreadsheet import (`importUnits` action + `ImportDialog` + `ImportUnitsButton`) existed end-to-end but was **rendered nowhere** — `/units` uses `UnitsExplorer`, and `unit-list.tsx` (which held the button) is dead code. So units couldn't actually be imported in the app, and P1's share-gate had no surface.

## Change
- **`UnitsHeaderActions`** now renders `<ImportUnitsButton/>` (board+) — the import (and the 100%-share gate) finally has a reachable home.
- New **"Tulajdoni hányad" KPI** in the units strip: the building's total ownership share with a **"· cél 100%"** target (turns moss/complete at 100%). Adds `UnitsKpis.ownershipShareTotal`.
- i18n (hu+en).

## Validated live (local dev, over tailnet)
- KPI shows Duna Residence at **92,5%**.
- Importing a 10% unit is **rejected** by the gate — *"…would exceed 100% (existing 92.50% + import 10.00% = 102.50%)"* — **no row written**.
- 291 tests pass; tsc + lint clean.

## Next
The multi-step wizard (basics → SZMSZ upload → units → governance → invites) + per-building setup checklist build on this.

Minor follow-up: import error strings are English app-wide (pre-existing) — worth a localization pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)