### PR TITLE
feat(onboarding): board setup-checklist card on dashboard (SZMSZ P4)

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -6,6 +6,7 @@ import {
   getBuildingName,
   getFollowups,
   getMemberDashboard,
+  getOnboardingChecklist,
 } from "@/lib/dashboard-dal";
 import { BoardDashboard } from "@/components/dashboard/board-dashboard";
 import { MemberDashboard } from "@/components/dashboard/member-dashboard";
@@ -38,10 +39,11 @@ export default async function DashboardPage({ params }: Props) {
         representativeRegistryDeadline: true,
       },
     });
-    const [data, followups, hasCommittee] = await Promise.all([
+    const [data, followups, hasCommittee, onboarding] = await Promise.all([
       getBoardDashboard(),
       getFollowups(),
       hasActiveAuditCommittee(prisma, buildingId),
+      getOnboardingChecklist(),
     ]);
     const registryStatus = compliance
       ? getRegistryStatus({
@@ -61,6 +63,7 @@ export default async function DashboardPage({ params }: Props) {
           requiresAuditCommittee: compliance?.requiresAuditCommittee ?? false,
           hasActiveCommittee: hasCommittee,
         }}
+        onboarding={onboarding}
       />
     );
   }

--- a/src/components/dashboard/board-dashboard.tsx
+++ b/src/components/dashboard/board-dashboard.tsx
@@ -4,10 +4,12 @@ import type {
   BoardDashboardData,
   BoardActivityItem,
   FollowupItem,
+  OnboardingChecklist,
 } from "@/lib/dashboard-dal";
 import type { RegistryStatus } from "@/lib/officer-registry";
 import { OfficerRegistryBanner } from "@/components/compliance/officer-registry-banner";
 import { AuditCommitteeRequiredBanner } from "@/components/compliance/audit-committee-required-banner";
+import { SetupChecklist } from "./setup-checklist";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -74,6 +76,8 @@ interface Props {
     requiresAuditCommittee: boolean;
     hasActiveCommittee: boolean;
   };
+  /** Onboarding setup progress; rendered only while setup is incomplete. */
+  onboarding?: OnboardingChecklist;
 }
 
 export async function BoardDashboard({
@@ -83,6 +87,7 @@ export async function BoardDashboard({
   followups,
   activeBuildingName: _activeBuildingName,
   compliance,
+  onboarding,
 }: Props) {
   const t = await getTranslations({ locale, namespace: "dashboard" });
   const tCompliance = await getTranslations({ locale, namespace: "compliance" });
@@ -151,6 +156,11 @@ export async function BoardDashboard({
             dismiss: tCompliance("auditCommittee.dismiss"),
           }}
         />
+      )}
+
+      {/* ── Onboarding setup checklist (hidden once complete) ──────────── */}
+      {onboarding && !onboarding.allComplete && (
+        <SetupChecklist locale={locale} checklist={onboarding} />
       )}
 
       {/* ── Page header ────────────────────────────────────────────────── */}

--- a/src/components/dashboard/setup-checklist.tsx
+++ b/src/components/dashboard/setup-checklist.tsx
@@ -1,0 +1,165 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import type { OnboardingChecklist } from "@/lib/dashboard-dal";
+
+interface Props {
+  locale: string;
+  checklist: OnboardingChecklist;
+}
+
+/**
+ * Board onboarding progress card. The dashboard only mounts this while the
+ * building setup is incomplete (`checklist.allComplete === false`), so it
+ * auto-hides once every step is done.
+ */
+export async function SetupChecklist({ locale, checklist }: Props) {
+  const t = await getTranslations({ locale, namespace: "onboarding.checklist" });
+  const pct = Math.round((checklist.doneCount / checklist.total) * 100);
+
+  return (
+    <div
+      style={{
+        background: "var(--color-card)",
+        border:
+          "1px solid color-mix(in srgb, var(--color-ochre) 35%, transparent)",
+        borderRadius: "16px",
+        padding: "22px 24px",
+        marginBottom: "24px",
+      }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div
+            className="font-mono"
+            style={{
+              fontSize: "10px",
+              color: "var(--color-ochre)",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+            }}
+          >
+            {t("eyebrow")}
+          </div>
+          <h2
+            style={{
+              fontFamily: "var(--font-space-grotesk), sans-serif",
+              fontSize: "22px",
+              fontWeight: 500,
+              letterSpacing: "-0.02em",
+              marginTop: "4px",
+            }}
+          >
+            {t("title")}
+          </h2>
+          <p
+            style={{
+              color: "var(--color-ink-soft)",
+              fontSize: "13px",
+              margin: "4px 0 0",
+              maxWidth: "60ch",
+            }}
+          >
+            {t("subtitle")}
+          </p>
+        </div>
+        <div
+          className="font-mono"
+          style={{
+            fontSize: "12px",
+            color: "var(--color-muted)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {t("progress", {
+            done: checklist.doneCount,
+            total: checklist.total,
+            pct,
+          })}
+        </div>
+      </div>
+
+      <ul className="grid gap-2" style={{ marginTop: "16px" }}>
+        {checklist.items.map((item) => (
+          <li key={item.key}>
+            <Link
+              href={`/${locale}${item.href}`}
+              className="flex items-center gap-3 transition-opacity hover:opacity-80"
+              style={{
+                padding: "10px 12px",
+                borderRadius: "10px",
+                background: item.done
+                  ? "color-mix(in srgb, var(--color-moss) 8%, transparent)"
+                  : "var(--color-bg-2)",
+                border: item.done
+                  ? "1px solid color-mix(in srgb, var(--color-moss) 25%, transparent)"
+                  : "1px solid color-mix(in srgb, var(--color-ink) 8%, transparent)",
+              }}
+            >
+              <CheckMark done={item.done} />
+              <span
+                style={{
+                  flex: 1,
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  color: item.done
+                    ? "var(--color-ink-soft)"
+                    : "var(--color-ink)",
+                  textDecoration: item.done ? "line-through" : "none",
+                }}
+              >
+                {t(`items.${item.key}`)}
+              </span>
+              {!item.done && (
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: "11px",
+                    fontWeight: 600,
+                    color: "var(--color-ochre)",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {t("action")} →
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function CheckMark({ done }: { done: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex items-center justify-center shrink-0"
+      style={{
+        width: "20px",
+        height: "20px",
+        borderRadius: "999px",
+        background: done ? "var(--color-moss)" : "transparent",
+        border: done
+          ? "none"
+          : "2px solid color-mix(in srgb, var(--color-ink) 25%, transparent)",
+        color: "#f5f2e6",
+      }}
+    >
+      {done && (
+        <svg
+          width="11"
+          height="11"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      )}
+    </span>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2918,6 +2918,22 @@
     "planEnterprise": "Enterprise",
     "planLegacy": "Legacy"
   },
+  "onboarding": {
+    "checklist": {
+      "eyebrow": "Setup",
+      "title": "Building setup",
+      "subtitle": "A few steps to complete your building's data. This list disappears once everything is done.",
+      "progress": "{done}/{total} done · {pct}%",
+      "action": "Set up",
+      "items": {
+        "units": "Record units",
+        "shares": "Ownership shares reach 100%",
+        "owners": "Owners assigned to every unit",
+        "meeting": "First general meeting scheduled",
+        "documents": "First document uploaded"
+      }
+    }
+  },
   "dashboard": {
     "newTask": "New task",
     "greeting": {

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2918,6 +2918,22 @@
     "planEnterprise": "Vallalati",
     "planLegacy": "Legacy"
   },
+  "onboarding": {
+    "checklist": {
+      "eyebrow": "Beüzemelés",
+      "title": "Társasház beállítása",
+      "subtitle": "Néhány lépés, hogy a társasház adatai teljesek legyenek. A lista eltűnik, amint mindennel végeztél.",
+      "progress": "{done}/{total} kész · {pct}%",
+      "action": "Beállítás",
+      "items": {
+        "units": "Albetétek rögzítése",
+        "shares": "Tulajdoni hányadok elérik a 100%-ot",
+        "owners": "Tulajdonosok hozzárendelve minden albetéthez",
+        "meeting": "Első közgyűlés ütemezve",
+        "documents": "Első dokumentum feltöltve"
+      }
+    }
+  },
   "dashboard": {
     "newTask": "Új teendő",
     "greeting": {

--- a/src/lib/dashboard-dal.ts
+++ b/src/lib/dashboard-dal.ts
@@ -1001,3 +1001,70 @@ export async function getBuildingName(buildingId: string) {
     select: { name: true },
   });
 }
+
+// ─── Onboarding setup checklist ─────────────────────────────────────────────
+
+export interface ChecklistItem {
+  /** i18n key under `onboarding.checklist.items` */
+  key: "units" | "shares" | "owners" | "meeting" | "documents";
+  done: boolean;
+  /** Where to go to complete this step (locale-less app path). */
+  href: string;
+}
+
+export interface OnboardingChecklist {
+  items: ChecklistItem[];
+  doneCount: number;
+  total: number;
+  allComplete: boolean;
+}
+
+/**
+ * Building-setup progress for the board onboarding card. Auto-hides once every
+ * item is done (the dashboard only renders it while `allComplete` is false).
+ */
+export const getOnboardingChecklist = cache(
+  async (): Promise<OnboardingChecklist> => {
+    const { buildingId } = await requireBuildingContext();
+    const now = new Date();
+
+    const [unitCount, shareAgg, ownerUnitCount, upcomingMeetings, docCount] =
+      await Promise.all([
+        prisma.unit.count({ where: { buildingId } }),
+        prisma.unit.aggregate({
+          where: { buildingId },
+          _sum: { ownershipShare: true },
+        }),
+        prisma.unit.count({
+          where: { buildingId, unitUsers: { some: { relationship: "OWNER" } } },
+        }),
+        prisma.meeting.count({ where: { buildingId, date: { gte: now } } }),
+        prisma.document.count({ where: { category: { buildingId } } }),
+      ]);
+
+    const shareTotal = Number(shareAgg._sum.ownershipShare ?? 0);
+    const items: ChecklistItem[] = [
+      { key: "units", done: unitCount > 0, href: "/units" },
+      {
+        key: "shares",
+        done: unitCount > 0 && Math.abs(shareTotal - 1) <= 0.0001,
+        href: "/units",
+      },
+      {
+        key: "owners",
+        done: unitCount > 0 && ownerUnitCount === unitCount,
+        href: "/residents",
+      },
+      { key: "meeting", done: upcomingMeetings > 0, href: "/voting/meetings" },
+      { key: "documents", done: docCount > 0, href: "/documents" },
+    ];
+
+    const doneCount = items.filter((i) => i.done).length;
+    return {
+      items,
+      doneCount,
+      total: items.length,
+      allComplete: doneCount === items.length,
+    };
+  },
+);


### PR DESCRIPTION
## What

Adds a **building-setup progress card** to the board dashboard — the next onboarding step after the units import (#97) and ownership-share KPI (#98). It surfaces the key setup tasks and links each to where it's completed:

- ✅ **Albetétek rögzítése** — at least one unit recorded
- **Tulajdoni hányadok elérik a 100%-ot** — ownership shares sum to 100% (±0.01%)
- **Tulajdonosok hozzárendelve minden albetéthez** — every unit has an OWNER
- **Első közgyűlés ütemezve** — an upcoming meeting exists
- **Első dokumentum feltöltve** — at least one document

The card **auto-hides once every item is done** (`allComplete`), so established buildings never see it.

## How

- `getOnboardingChecklist()` in `dashboard-dal.ts` — cached, building-scoped; computes each item with cheap `count`/`aggregate` queries in one `Promise.all`.
- `SetupChecklist` server component (Tiles design system) rendered above the page header in `BoardDashboard`, gated on `!allComplete`.
- i18n hu+en under `onboarding.checklist.*`.

## Validation

Validated live on local dev (over the tailnet) as a board user for *Duna Residence*: card showed **2/5 · 40%** — units + documents checked off; shares (93%), owners, and meeting pending with "Beállítás →" links to `/units`, `/residents`, `/voting/meetings`. Matches the dashboard KPIs. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)