### PR TITLE
fix(residents): correct invite role i18n + derive unit relationship from role

### DIFF
--- a/src/components/residents/invite-resident-modal.tsx
+++ b/src/components/residents/invite-resident-modal.tsx
@@ -37,9 +37,6 @@ export function InviteResidentModal({
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<(typeof ROLES)[number]>("OWNER");
   const [unitId, setUnitId] = useState("");
-  const [relationship, setRelationship] = useState<
-    (typeof RELATIONSHIPS)[number]
-  >("OWNER");
   const [submitting, setSubmitting] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -56,9 +53,16 @@ export function InviteResidentModal({
     setEmail("");
     setRole("OWNER");
     setUnitId("");
-    setRelationship("OWNER");
     setErrors({});
   }
+
+  // A person's unit relationship follows from their role: a TENANT rents,
+  // while an OWNER owns — and board members must be owners (Tht. § 27),
+  // so anything that isn't a TENANT is recorded as the unit's OWNER. Derived
+  // (not user-picked) to keep the two consistent — no "tenant owner" or
+  // "board-member tenant" combinations.
+  const relationship: (typeof RELATIONSHIPS)[number] =
+    role === "TENANT" ? "TENANT" : "OWNER";
 
   function validate(): Record<string, string> {
     const errs: Record<string, string> = {};
@@ -187,52 +191,26 @@ export function InviteResidentModal({
           </select>
         </VotingField>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <VotingField
-            label={t("invite.unitLabel")}
-            htmlFor="invite-unit"
-            hint={t("invite.unitHint")}
+        <VotingField
+          label={t("invite.unitLabel")}
+          htmlFor="invite-unit"
+          hint={t("invite.unitHint")}
+        >
+          <select
+            id="invite-unit"
+            value={unitId}
+            onChange={(e) => setUnitId(e.target.value)}
+            style={votingInputStyle(false)}
           >
-            <select
-              id="invite-unit"
-              value={unitId}
-              onChange={(e) => setUnitId(e.target.value)}
-              style={votingInputStyle(false)}
-            >
-              <option value="">{t("invite.unitNone")}</option>
-              {sortedUnits.map((u) => (
-                <option key={u.id} value={u.id}>
-                  {u.stairwell ? `${u.stairwell} · ` : ""}
-                  {u.number}
-                </option>
-              ))}
-            </select>
-          </VotingField>
-          <VotingField
-            label={t("invite.relationshipLabel")}
-            htmlFor="invite-relationship"
-          >
-            <select
-              id="invite-relationship"
-              value={relationship}
-              disabled={!unitId}
-              onChange={(e) =>
-                setRelationship(e.target.value as (typeof RELATIONSHIPS)[number])
-              }
-              style={{
-                ...votingInputStyle(false),
-                opacity: unitId ? 1 : 0.5,
-                cursor: unitId ? "pointer" : "not-allowed",
-              }}
-            >
-              {RELATIONSHIPS.map((r) => (
-                <option key={r} value={r}>
-                  {t(`invite.rel_${r}`)}
-                </option>
-              ))}
-            </select>
-          </VotingField>
-        </div>
+            <option value="">{t("invite.unitNone")}</option>
+            {sortedUnits.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.stairwell ? `${u.stairwell} · ` : ""}
+                {u.number}
+              </option>
+            ))}
+          </select>
+        </VotingField>
 
         <div
           className="flex justify-end items-center gap-2"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -134,9 +134,6 @@
       "unitLabel": "Unit (optional)",
       "unitHint": "Leave empty to not associate with a unit.",
       "unitNone": "No unit",
-      "relationshipLabel": "Relationship",
-      "rel_OWNER": "Owner",
-      "rel_TENANT": "Tenant",
       "sendCta": "Send invitation",
       "sent": "Invitation sent"
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -129,7 +129,7 @@
       "roleLabel": "Role",
       "roleHint": "Determines what the resident can see and do.",
       "role_BOARD_MEMBER": "Board member",
-      "role_RESIDENT": "Owner",
+      "role_OWNER": "Owner",
       "role_TENANT": "Tenant",
       "unitLabel": "Unit (optional)",
       "unitHint": "Leave empty to not associate with a unit.",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -129,7 +129,7 @@
       "roleLabel": "Szerep",
       "roleHint": "A szerep meghatározza, mit lát és tehet a lakó.",
       "role_BOARD_MEMBER": "Képviselő",
-      "role_RESIDENT": "Tulajdonos",
+      "role_OWNER": "Tulajdonos",
       "role_TENANT": "Bérlő",
       "unitLabel": "Lakás (opcionális)",
       "unitHint": "Üresen hagyva nem kötjük lakáshoz.",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -134,9 +134,6 @@
       "unitLabel": "Lakás (opcionális)",
       "unitHint": "Üresen hagyva nem kötjük lakáshoz.",
       "unitNone": "Nincs hozzárendelve",
-      "relationshipLabel": "Viszony",
-      "rel_OWNER": "Tulajdonos",
-      "rel_TENANT": "Bérlő",
       "sendCta": "Meghívó küldése",
       "sent": "Meghívó elküldve"
     },


### PR DESCRIPTION
Two related correctness fixes in the resident-invite modal (both surfaced while deep-linking to `/residents` from the onboarding wizard, #101).

## 1. Stale role i18n key
The modal renders roles `["BOARD_MEMBER","OWNER","TENANT"]` (matching `BuildingRole`, where RESIDENT was removed in Phase 3b) via `t(\`invite.role_${r}\`)`, but the bundle still had `role_RESIDENT` → `IntlError: MISSING_MESSAGE: role_OWNER` and a raw key shown. Renamed `role_RESIDENT` → `role_OWNER` (hu + en; value unchanged).

## 2. Role ↔ relationship could contradict
"Szerep" (building role) and "Viszony" (unit relationship) were independent selectors, so you could pick e.g. **TENANT role + OWNER relationship**, or mark a **board member as a tenant** — but board members must be owners (Tht. § 27).

The relationship is fully implied by the role — TENANT rents, everyone else (owner, board member) owns — so it's now **derived** (`role === "TENANT" ? "TENANT" : "OWNER"`) and the **redundant Viszony selector was removed**. The modal keeps only email / role / unit. Removed the now-orphaned i18n keys (`relationshipLabel`, `relationshipLockedHint`, `rel_OWNER`, `rel_TENANT`).

## Validation
Live (tailnet dev): role dropdown renders Képviselő / Tulajdonos / Bérlő; changing role derives the correct relationship; modal now shows only the three fields; `browser_console_messages` clean. `tsc` + `eslint` clean; JSON valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)