### PR TITLE
fix(import): open file picker via ref click (Safari-safe)

### DIFF
--- a/src/components/onboarding/szmsz-ai-extract.tsx
+++ b/src/components/onboarding/szmsz-ai-extract.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { importUnits } from "@/app/actions/units";
 import type { ImportRow } from "@/lib/import/types";
@@ -35,6 +35,7 @@ export function SzmszAiExtract({
   const [extraction, setExtraction] = useState<Extraction | null>(null);
   const [importMsg, setImportMsg] = useState<string | null>(null);
   const [govMsg, setGovMsg] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const nf = new Intl.NumberFormat(locale === "en" ? "en-US" : "hu-HU");
 
@@ -165,8 +166,10 @@ export function SzmszAiExtract({
         </div>
       </div>
 
-      <label
-        htmlFor="szmsz-ai-file"
+      <button
+        type="button"
+        disabled={busy !== "idle"}
+        onClick={() => fileInputRef.current?.click()}
         className="inline-flex items-center gap-2 transition-opacity hover:opacity-90"
         style={{
           marginTop: "12px",
@@ -181,19 +184,19 @@ export function SzmszAiExtract({
         }}
       >
         {busy === "extracting" ? t("extracting") : t("uploadCta")}
-        <input
-          id="szmsz-ai-file"
-          type="file"
-          accept="application/pdf"
-          disabled={busy !== "idle"}
-          style={{ display: "none" }}
-          onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) handleFile(f);
-            e.target.value = "";
-          }}
-        />
-      </label>
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/pdf"
+        disabled={busy !== "idle"}
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) handleFile(f);
+          e.target.value = "";
+        }}
+      />
 
       <p className="font-mono" style={{ fontSize: "10.5px", color: "var(--color-muted)", marginTop: "8px", letterSpacing: "0.02em" }}>
         {t("gdprNote")}

--- a/src/components/shared/import-dialog.tsx
+++ b/src/components/shared/import-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useTranslations } from "next-intl";
 import {
   X,
@@ -48,6 +48,7 @@ export function ImportDialog({
   const [result, setResult] = useState<ImportResult | null>(null);
   const [error, setError] = useState("");
   const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   function reset() {
     setStep("upload");
@@ -292,16 +293,21 @@ export function ImportDialog({
               <FileSpreadsheet className="h-12 w-12 text-ink-soft mx-auto mb-4" />
               <p className="text-sm font-medium text-ink mb-1">{t("dropFileHere")}</p>
               <p className="text-xs text-muted mb-4">{t("acceptedFormats")}: .xlsx, .csv</p>
-              <label className="inline-flex items-center gap-2 rounded-lg bg-blue px-4 py-2.5 text-sm font-bold text-card cursor-pointer hover:opacity-90 transition-all">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="inline-flex items-center gap-2 rounded-lg bg-blue px-4 py-2.5 text-sm font-bold text-card cursor-pointer hover:opacity-90 transition-all"
+              >
                 <Upload className="h-4 w-4" />
                 {t("chooseFile")}
-                <input
-                  type="file"
-                  accept=".xlsx,.xls,.csv"
-                  className="hidden"
-                  onChange={handleFileInput}
-                />
-              </label>
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".xlsx,.xls,.csv"
+                className="hidden"
+                onChange={handleFileInput}
+              />
             </div>
           )}
 


### PR DESCRIPTION
## Bug

Clicking **"Fájl kiválasztása"** in the units import dialog did nothing — the OS file picker never opened.

## Cause

Both the units `ImportDialog` and the SZMSZ AI-extract upload used a `<label>` **wrapping** a `display:none` `<input type="file">`. That relies on implicit label→input activation, which is unreliable for **hidden** inputs in some browsers (notably Safari) — so the picker never fired.

## Fix

Replace the label with a real `<button>` that calls a **ref'd input's `.click()`** — the standard, bulletproof cross-browser pattern. Applied to both upload spots. Behaviour is unchanged where it already worked (Chromium).

## Validation

Live (tailnet dev, Chromium): both **"Fájl kiválasztása"** (units import) and **"SZMSZ PDF feltöltése"** (AI extract) open the file chooser; uploading the lakáslista still advances through the mapping → preview steps. `tsc` + `eslint` clean.

_(Reported on the manual onboarding test with the sample lakáslista/SZMSZ files.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)