### PR TITLE
fix(onboarding): SZMSZ-first wizard flow + upload/state/label fixes

### DIFF
--- a/src/app/api/onboarding/extract-szmsz/route.ts
+++ b/src/app/api/onboarding/extract-szmsz/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireBuildingContext } from "@/lib/auth";
 import { requireCapability } from "@/lib/authz";
+import { prisma } from "@/lib/prisma";
+import { getStorage } from "@/lib/storage";
 import { extractSzmszFromPdf } from "@/lib/szmsz-extract";
 
 // Base64 inflates ~33%; cap the decoded PDF around 15 MB.
@@ -41,7 +43,53 @@ export async function POST(request: NextRequest) {
     }
 
     const extraction = await extractSzmszFromPdf(pdfBase64, fileName);
-    return NextResponse.json(extraction);
+
+    // Also persist the uploaded PDF as a document in the building's SZMSZ
+    // category, so the "first document uploaded" step is genuinely satisfied.
+    // board.manage-gated here (the general documents API needs chair/admin
+    // publish authority, which onboarding board members may lack).
+    let stored = false;
+    try {
+      const szmszCategory = await prisma.documentCategory.findFirst({
+        where: { buildingId: ctx.buildingId, name: { contains: "SZMSZ", mode: "insensitive" } },
+        orderBy: { sortOrder: "asc" },
+        select: { id: true },
+      });
+      if (szmszCategory) {
+        const buffer = Buffer.from(pdfBase64, "base64");
+        const safeName = fileName?.trim() || "SZMSZ.pdf";
+        const put = await getStorage().put({
+          scope: "document",
+          fileName: safeName,
+          mimeType: "application/pdf",
+          body: buffer,
+        });
+        await prisma.document.create({
+          data: {
+            title: safeName.replace(/\.pdf$/i, ""),
+            categoryId: szmszCategory.id,
+            visibility: "BOARD_ONLY",
+            uploadedById: ctx.userId,
+            versions: {
+              create: {
+                versionNumber: 1,
+                fileUrl: put.url,
+                fileName: put.fileName,
+                fileSize: put.fileSize,
+                mimeType: put.mimeType,
+                uploadedById: ctx.userId,
+              },
+            },
+          },
+        });
+        stored = true;
+      }
+    } catch (storeErr) {
+      // Storing is best-effort — extraction still succeeds without it.
+      console.error("SZMSZ document store failed (non-fatal):", storeErr);
+    }
+
+    return NextResponse.json({ ...extraction, stored });
   } catch (error) {
     console.error("SZMSZ extraction failed:", error);
     return NextResponse.json(

--- a/src/components/onboarding/building-onboarding-wizard.tsx
+++ b/src/components/onboarding/building-onboarding-wizard.tsx
@@ -5,7 +5,9 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { ImportUnitsButton } from "@/components/units/import-units-button";
-import { SzmszAiExtract } from "./szmsz-ai-extract";
+import { SzmszAiExtract, type Extraction } from "./szmsz-ai-extract";
+import { importUnits } from "@/app/actions/units";
+import type { ImportRow } from "@/lib/import/types";
 
 type StepIndex = 0 | 1 | 2 | 3 | 4 | 5;
 const TOTAL_STEPS = 6;
@@ -50,6 +52,9 @@ export function BuildingOnboardingWizard({ locale }: { locale: string }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
+  // AI extraction is lifted here so it pre-fills the Units + Governance steps
+  // and survives step navigation (no re-upload/re-process).
+  const [extraction, setExtraction] = useState<Extraction | null>(null);
 
   const reload = useCallback(async () => {
     const res = await fetch("/api/onboarding", { cache: "no-store" });
@@ -134,9 +139,9 @@ export function BuildingOnboardingWizard({ locale }: { locale: string }) {
 
   const stepTitles = [
     t("steps.basics"),
-    t("steps.governance"),
-    t("steps.units"),
     t("steps.szmsz"),
+    t("steps.units"),
+    t("steps.governance"),
     t("steps.invites"),
     t("steps.review"),
   ];
@@ -187,7 +192,7 @@ export function BuildingOnboardingWizard({ locale }: { locale: string }) {
         {stepTitles[step]}
       </h2>
       <p style={{ color: "var(--color-ink-soft)", fontSize: "14px", margin: "0 0 24px" }}>
-        {t(`subtitles.${["basics", "governance", "units", "szmsz", "invites", "review"][step]}`)}
+        {t(`subtitles.${["basics", "szmsz", "units", "governance", "invites", "review"][step]}`)}
       </p>
 
       {error && (
@@ -217,31 +222,35 @@ export function BuildingOnboardingWizard({ locale }: { locale: string }) {
         />
       )}
       {step === 1 && (
-        <GovernanceStep
+        <SzmszStep
           state={state}
-          saving={saving}
+          locale={locale}
+          extraction={extraction}
+          onExtracted={setExtraction}
+          onReload={reload}
           onBack={() => setStep(0)}
-          onSave={async (p) => {
-            if (await savePatch({ action: "governance", ...p })) setStep(2);
-          }}
+          onNext={() => setStep(2)}
         />
       )}
       {step === 2 && (
         <UnitsStep
           state={state}
           locale={locale}
+          extraction={extraction}
           onReload={reload}
           onBack={() => setStep(1)}
           onNext={() => setStep(3)}
         />
       )}
       {step === 3 && (
-        <SzmszStep
+        <GovernanceStep
           state={state}
-          locale={locale}
-          onReload={reload}
+          saving={saving}
+          extraction={extraction}
           onBack={() => setStep(2)}
-          onNext={() => setStep(4)}
+          onSave={async (p) => {
+            if (await savePatch({ action: "governance", ...p })) setStep(4);
+          }}
         />
       )}
       {step === 4 && (
@@ -363,11 +372,13 @@ function BasicsStep({
 function GovernanceStep({
   state,
   saving,
+  extraction,
   onBack,
   onSave,
 }: {
   state: OnboardingState;
   saving: boolean;
+  extraction: Extraction | null;
   onBack: () => void;
   onSave: (p: {
     reserveTargetHUF: number;
@@ -376,9 +387,19 @@ function GovernanceStep({
   }) => Promise<void>;
 }) {
   const t = useTranslations("buildingOnboarding");
-  const [reserve, setReserve] = useState(String(state.building.reserveTargetHUF || ""));
-  const [majority, setMajority] = useState(state.building.defaultMajority);
-  const [basis, setBasis] = useState(state.building.costAllocationBasis);
+  // Pre-fill from the SZMSZ extraction when present, else the saved building.
+  const g = extraction?.governance;
+  const [reserve, setReserve] = useState(
+    String((g?.reserveTargetHUF ?? state.building.reserveTargetHUF) || ""),
+  );
+  const [majority, setMajority] = useState(
+    g?.defaultMajority || state.building.defaultMajority,
+  );
+  const [basis, setBasis] = useState(
+    g?.costAllocationBasis || state.building.costAllocationBasis,
+  );
+  const prefilled =
+    !!g && (g.reserveTargetHUF != null || !!g.defaultMajority || !!g.costAllocationBasis);
 
   return (
     <form
@@ -391,6 +412,17 @@ function GovernanceStep({
         });
       }}
     >
+      {prefilled && (
+        <p
+          style={{
+            fontSize: "12.5px",
+            color: "var(--color-blue)",
+            margin: "0 0 14px",
+          }}
+        >
+          {t("prefilledFromSzmsz")}
+        </p>
+      )}
       <Field label={t("fields.reserveTarget")} htmlFor="ob-reserve" hint={t("fields.reserveTargetHint")}>
         <input
           id="ob-reserve"
@@ -431,22 +463,59 @@ function GovernanceStep({
 function UnitsStep({
   state,
   locale,
+  extraction,
   onReload,
   onBack,
   onNext,
 }: {
   state: OnboardingState;
   locale: string;
+  extraction: Extraction | null;
   onReload: () => Promise<void>;
   onBack: () => void;
   onNext: () => void;
 }) {
   const t = useTranslations("buildingOnboarding");
+  const ta = useTranslations("buildingOnboarding.ai");
   const { unitCount, ownershipShare, sharesComplete } = state.progress;
-  const pct = (ownershipShare * 100).toLocaleString(locale === "en" ? "en-US" : "hu-HU", {
+  const intlLocale = locale === "en" ? "en-US" : "hu-HU";
+  const pct = (ownershipShare * 100).toLocaleString(intlLocale, {
     minimumFractionDigits: 1,
     maximumFractionDigits: 1,
   });
+
+  const extractedUnits = extraction?.units ?? [];
+  const extractedShare = extractedUnits.reduce((s, u) => s + (u.ownershipShare || 0), 0);
+  const extractedComplete = Math.abs(extractedShare - 1) <= 0.0001;
+  const [importing, setImporting] = useState(false);
+  const [importMsg, setImportMsg] = useState<string | null>(null);
+
+  async function importExtracted() {
+    setImportMsg(null);
+    setImporting(true);
+    try {
+      const rows: ImportRow[] = extractedUnits.map((u) => ({
+        unit_number: u.number,
+        floor: String(u.floor),
+        size_sqm: String(u.size),
+        ownership_share: String(u.ownershipShare),
+      }));
+      const result = await importUnits(rows);
+      if (result.created > 0) {
+        setImportMsg(ta("imported", { count: result.created }));
+        await onReload();
+      } else {
+        const first = result.errors[0]?.message;
+        setImportMsg(first ? `${ta("importNone")} — ${first}` : ta("importNone"));
+      }
+    } catch {
+      setImportMsg(ta("importError"));
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const showExtracted = extractedUnits.length > 0 && unitCount === 0;
 
   return (
     <div>
@@ -455,8 +524,61 @@ function UnitsStep({
         title={t("units.statusTitle", { count: unitCount })}
         detail={t("units.statusShare", { pct })}
       />
+
+      {showExtracted && (
+        <div
+          className="rounded-xl"
+          style={{
+            marginTop: "16px",
+            padding: "14px 16px",
+            background: "color-mix(in srgb, var(--color-blue) 6%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--color-blue) 25%, transparent)",
+          }}
+        >
+          <div className="flex items-center justify-between" style={{ marginBottom: "8px" }}>
+            <span className="font-mono" style={{ fontSize: "11px", color: "var(--color-muted)", letterSpacing: "0.06em", textTransform: "uppercase" }}>
+              {ta("unitsFound", { count: extractedUnits.length })}
+            </span>
+            <span className="font-mono" style={{ fontSize: "11px", fontWeight: 600, color: extractedComplete ? "var(--color-moss)" : "var(--color-ochre)" }}>
+              {ta("shareSum", { pct: (extractedShare * 100).toLocaleString(intlLocale, { minimumFractionDigits: 1, maximumFractionDigits: 1 }) })}
+            </span>
+          </div>
+          <div style={{ maxHeight: "200px", overflowY: "auto", borderRadius: "8px", border: "1px solid color-mix(in srgb, var(--color-ink) 10%, transparent)", background: "var(--color-card)" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "12.5px" }}>
+              <thead>
+                <tr style={{ background: "var(--color-bg-3)", textAlign: "left" }}>
+                  <ExtractTh>{ta("colNumber")}</ExtractTh>
+                  <ExtractTh>{ta("colFloor")}</ExtractTh>
+                  <ExtractTh>{ta("colSize")}</ExtractTh>
+                  <ExtractTh>{ta("colShare")}</ExtractTh>
+                </tr>
+              </thead>
+              <tbody>
+                {extractedUnits.map((u, i) => (
+                  <tr key={`${u.number}-${i}`} style={{ borderTop: "1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)" }}>
+                    <ExtractTd>{u.number}</ExtractTd>
+                    <ExtractTd>{u.floor}</ExtractTd>
+                    <ExtractTd>{u.size} m²</ExtractTd>
+                    <ExtractTd>{(u.ownershipShare * 100).toLocaleString(intlLocale, { maximumFractionDigits: 4 })}%</ExtractTd>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex flex-wrap items-center gap-3" style={{ marginTop: "12px" }}>
+            <button type="button" onClick={importExtracted} disabled={importing} className="transition-opacity hover:opacity-90 disabled:opacity-50" style={primaryLinkStyle}>
+              {importing ? ta("importing") : ta("importCta")}
+            </button>
+            {importMsg && <span style={{ fontSize: "13px", color: "var(--color-ink-soft)" }}>{importMsg}</span>}
+          </div>
+          {!extractedComplete && (
+            <p style={{ fontSize: "12px", color: "var(--color-ochre)", marginTop: "6px" }}>{ta("shareWarning")}</p>
+          )}
+        </div>
+      )}
+
       <div className="flex flex-wrap items-center gap-3" style={{ marginTop: "16px" }}>
-        <ImportUnitsButton />
+        <ImportUnitsButton onImported={onReload} />
         <button type="button" onClick={onReload} style={ghostButtonStyle}>
           {t("refresh")}
         </button>
@@ -469,17 +591,32 @@ function UnitsStep({
   );
 }
 
+function ExtractTh({ children }: { children: React.ReactNode }) {
+  return (
+    <th className="font-mono" style={{ padding: "7px 10px", fontSize: "10px", color: "var(--color-muted)", letterSpacing: "0.05em", textTransform: "uppercase", fontWeight: 600 }}>
+      {children}
+    </th>
+  );
+}
+function ExtractTd({ children }: { children: React.ReactNode }) {
+  return <td style={{ padding: "6px 10px" }}>{children}</td>;
+}
+
 // ── Step: SZMSZ ─────────────────────────────────────────────────────────────
 
 function SzmszStep({
   state,
   locale,
+  extraction,
+  onExtracted,
   onReload,
   onBack,
   onNext,
 }: {
   state: OnboardingState;
   locale: string;
+  extraction: Extraction | null;
+  onExtracted: (e: Extraction) => void;
   onReload: () => Promise<void>;
   onBack: () => void;
   onNext: () => void;
@@ -492,7 +629,12 @@ function SzmszStep({
 
   return (
     <div>
-      <SzmszAiExtract locale={locale} onReload={onReload} />
+      <SzmszAiExtract
+        locale={locale}
+        extraction={extraction}
+        onExtracted={onExtracted}
+        onReload={onReload}
+      />
       <StatusCard
         done={szmszDocCount > 0}
         title={t("szmsz.statusTitle", { count: szmszDocCount })}

--- a/src/components/onboarding/szmsz-ai-extract.tsx
+++ b/src/components/onboarding/szmsz-ai-extract.tsx
@@ -2,48 +2,50 @@
 
 import { useState, useRef } from "react";
 import { useTranslations } from "next-intl";
-import { importUnits } from "@/app/actions/units";
-import type { ImportRow } from "@/lib/import/types";
 
-interface ExtractedUnit {
+export interface ExtractedUnit {
   number: string;
   floor: number;
   size: number;
   ownershipShare: number;
 }
-interface Extraction {
+export interface Extraction {
   units: ExtractedUnit[];
   governance: {
     reserveTargetHUF: number | null;
     defaultMajority: string | null;
     costAllocationBasis: string | null;
   };
+  stored?: boolean;
 }
 
-const SHARE_EPS = 0.0001;
-
+/**
+ * SZMSZ upload + AI extraction. On success it lifts the result to the wizard
+ * (via onExtracted) so the Units and Governance steps can pre-fill from it,
+ * and the extraction survives step navigation. The uploaded PDF is also stored
+ * server-side in the Bylaws category (onReload refreshes the doc count).
+ */
 export function SzmszAiExtract({
   locale,
+  extraction,
+  onExtracted,
   onReload,
 }: {
   locale: string;
+  extraction: Extraction | null;
+  onExtracted: (e: Extraction) => void;
   onReload: () => Promise<void>;
 }) {
   const t = useTranslations("buildingOnboarding.ai");
-  const [busy, setBusy] = useState<"idle" | "extracting" | "importing" | "gov">("idle");
+  const tg = useTranslations("buildingOnboarding");
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [extraction, setExtraction] = useState<Extraction | null>(null);
-  const [importMsg, setImportMsg] = useState<string | null>(null);
-  const [govMsg, setGovMsg] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const nf = new Intl.NumberFormat(locale === "en" ? "en-US" : "hu-HU");
 
   async function handleFile(file: File) {
     setError(null);
-    setExtraction(null);
-    setImportMsg(null);
-    setGovMsg(null);
     if (file.type !== "application/pdf") {
       setError(t("notPdf"));
       return;
@@ -52,7 +54,7 @@ export function SzmszAiExtract({
       setError(t("tooLarge"));
       return;
     }
-    setBusy("extracting");
+    setBusy(true);
     try {
       const base64 = await fileToBase64(file);
       const res = await fetch("/api/onboarding/extract-szmsz", {
@@ -65,81 +67,19 @@ export function SzmszAiExtract({
         setError(d?.error ?? t("extractFailed"));
         return;
       }
-      setExtraction((await res.json()) as Extraction);
+      const result = (await res.json()) as Extraction;
+      onExtracted(result);
+      await onReload(); // stored doc → refresh the doc count
     } catch {
       setError(t("extractFailed"));
     } finally {
-      setBusy("idle");
+      setBusy(false);
     }
   }
 
   const shareSum =
     extraction?.units.reduce((s, u) => s + (u.ownershipShare || 0), 0) ?? 0;
-  const sharesComplete = Math.abs(shareSum - 1) <= SHARE_EPS;
-
-  async function handleImport() {
-    if (!extraction) return;
-    setImportMsg(null);
-    setBusy("importing");
-    try {
-      const rows: ImportRow[] = extraction.units.map((u) => ({
-        unit_number: u.number,
-        floor: String(u.floor),
-        size_sqm: String(u.size),
-        ownership_share: String(u.ownershipShare),
-      }));
-      const result = await importUnits(rows);
-      if (result.created > 0) {
-        setImportMsg(t("imported", { count: result.created }));
-        await onReload();
-      } else {
-        const first = result.errors[0]?.message;
-        setImportMsg(first ? `${t("importNone")} — ${first}` : t("importNone"));
-      }
-    } catch {
-      setImportMsg(t("importError"));
-    } finally {
-      setBusy("idle");
-    }
-  }
-
-  async function handleApplyGovernance() {
-    if (!extraction) return;
-    const g = extraction.governance;
-    const payload: Record<string, unknown> = { action: "governance" };
-    if (g.reserveTargetHUF != null) payload.reserveTargetHUF = g.reserveTargetHUF;
-    if (g.defaultMajority) payload.defaultMajority = g.defaultMajority;
-    if (g.costAllocationBasis) payload.costAllocationBasis = g.costAllocationBasis;
-    if (Object.keys(payload).length === 1) {
-      setGovMsg(t("govNone"));
-      return;
-    }
-    setGovMsg(null);
-    setBusy("gov");
-    try {
-      const res = await fetch("/api/onboarding", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        setGovMsg(t("govError"));
-        return;
-      }
-      setGovMsg(t("govApplied"));
-      await onReload();
-    } catch {
-      setGovMsg(t("govError"));
-    } finally {
-      setBusy("idle");
-    }
-  }
-
-  const hasGovernance =
-    !!extraction &&
-    (extraction.governance.reserveTargetHUF != null ||
-      !!extraction.governance.defaultMajority ||
-      !!extraction.governance.costAllocationBasis);
+  const g = extraction?.governance;
 
   return (
     <div
@@ -151,24 +91,20 @@ export function SzmszAiExtract({
         border: "1px solid color-mix(in srgb, var(--color-blue) 25%, transparent)",
       }}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div
-            className="font-mono"
-            style={{ fontSize: "10px", color: "var(--color-blue)", letterSpacing: "0.1em", textTransform: "uppercase" }}
-          >
-            {t("eyebrow")}
-          </div>
-          <div style={{ fontSize: "15px", fontWeight: 600, marginTop: "3px" }}>{t("title")}</div>
-          <p style={{ fontSize: "13px", color: "var(--color-ink-soft)", margin: "3px 0 0", maxWidth: "56ch" }}>
-            {t("subtitle")}
-          </p>
-        </div>
+      <div
+        className="font-mono"
+        style={{ fontSize: "10px", color: "var(--color-blue)", letterSpacing: "0.1em", textTransform: "uppercase" }}
+      >
+        {t("eyebrow")}
       </div>
+      <div style={{ fontSize: "15px", fontWeight: 600, marginTop: "3px" }}>{t("title")}</div>
+      <p style={{ fontSize: "13px", color: "var(--color-ink-soft)", margin: "3px 0 0", maxWidth: "56ch" }}>
+        {t("subtitle")}
+      </p>
 
       <button
         type="button"
-        disabled={busy !== "idle"}
+        disabled={busy}
         onClick={() => fileInputRef.current?.click()}
         className="inline-flex items-center gap-2 transition-opacity hover:opacity-90"
         style={{
@@ -179,17 +115,17 @@ export function SzmszAiExtract({
           fontWeight: 600,
           background: "var(--color-ink)",
           color: "var(--color-bg)",
-          cursor: busy === "idle" ? "pointer" : "not-allowed",
-          opacity: busy === "extracting" ? 0.6 : 1,
+          cursor: busy ? "not-allowed" : "pointer",
+          opacity: busy ? 0.6 : 1,
         }}
       >
-        {busy === "extracting" ? t("extracting") : t("uploadCta")}
+        {busy ? t("extracting") : extraction ? t("reupload") : t("uploadCta")}
       </button>
       <input
         ref={fileInputRef}
         type="file"
         accept="application/pdf"
-        disabled={busy !== "idle"}
+        disabled={busy}
         style={{ display: "none" }}
         onChange={(e) => {
           const f = e.target.files?.[0];
@@ -209,105 +145,44 @@ export function SzmszAiExtract({
       )}
 
       {extraction && (
-        <div style={{ marginTop: "14px" }}>
-          {/* Units review */}
-          <div className="flex items-center justify-between" style={{ marginBottom: "6px" }}>
-            <span className="font-mono" style={{ fontSize: "11px", color: "var(--color-muted)", letterSpacing: "0.06em", textTransform: "uppercase" }}>
-              {t("unitsFound", { count: extraction.units.length })}
-            </span>
-            <span
-              className="font-mono"
-              style={{ fontSize: "11px", fontWeight: 600, color: sharesComplete ? "var(--color-moss)" : "var(--color-ochre)" }}
-            >
-              {t("shareSum", { pct: (shareSum * 100).toLocaleString(locale === "en" ? "en-US" : "hu-HU", { minimumFractionDigits: 1, maximumFractionDigits: 1 }) })}
-            </span>
+        <div
+          className="rounded-lg"
+          style={{
+            marginTop: "14px",
+            padding: "12px 14px",
+            background: "var(--color-bg-3)",
+            border: "1px solid color-mix(in srgb, var(--color-ink) 10%, transparent)",
+          }}
+        >
+          <div style={{ fontSize: "13px", fontWeight: 600 }}>
+            {t("summaryUnits", {
+              count: extraction.units.length,
+              pct: (shareSum * 100).toLocaleString(locale === "en" ? "en-US" : "hu-HU", {
+                minimumFractionDigits: 1,
+                maximumFractionDigits: 1,
+              }),
+            })}
           </div>
-
-          <div style={{ maxHeight: "240px", overflowY: "auto", borderRadius: "8px", border: "1px solid color-mix(in srgb, var(--color-ink) 10%, transparent)" }}>
-            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "12.5px" }}>
-              <thead>
-                <tr style={{ background: "var(--color-bg-3)", textAlign: "left" }}>
-                  <Th>{t("colNumber")}</Th>
-                  <Th>{t("colFloor")}</Th>
-                  <Th>{t("colSize")}</Th>
-                  <Th>{t("colShare")}</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {extraction.units.map((u, i) => (
-                  <tr key={`${u.number}-${i}`} style={{ borderTop: "1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)" }}>
-                    <Td>{u.number}</Td>
-                    <Td>{u.floor}</Td>
-                    <Td>{nf.format(u.size)} m²</Td>
-                    <Td>{(u.ownershipShare * 100).toLocaleString(locale === "en" ? "en-US" : "hu-HU", { maximumFractionDigits: 4 })}%</Td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-3" style={{ marginTop: "12px" }}>
-            <button
-              type="button"
-              onClick={handleImport}
-              disabled={busy !== "idle" || extraction.units.length === 0}
-              className="transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ padding: "9px 14px", borderRadius: "8px", fontSize: "13px", fontWeight: 600, background: "var(--color-ink)", color: "var(--color-bg)" }}
-            >
-              {busy === "importing" ? t("importing") : t("importCta")}
-            </button>
-            {importMsg && <span style={{ fontSize: "13px", color: "var(--color-ink-soft)" }}>{importMsg}</span>}
-          </div>
-          {!sharesComplete && (
-            <p style={{ fontSize: "12px", color: "var(--color-ochre)", marginTop: "6px" }}>{t("shareWarning")}</p>
+          {g && (g.reserveTargetHUF != null || g.defaultMajority || g.costAllocationBasis) && (
+            <ul style={{ fontSize: "13px", margin: "6px 0 0", paddingLeft: "16px", listStyle: "disc", color: "var(--color-ink-soft)" }}>
+              {g.reserveTargetHUF != null && (
+                <li>{t("govReserve", { amount: nf.format(g.reserveTargetHUF) })}</li>
+              )}
+              {g.defaultMajority && (
+                <li>{t("govMajority")}: {tg(`majority.${g.defaultMajority}`)}</li>
+              )}
+              {g.costAllocationBasis && (
+                <li>{t("govCostBasis")}: {tg(`costBasis.${g.costAllocationBasis}`)}</li>
+              )}
+            </ul>
           )}
-
-          {/* Governance review */}
-          {hasGovernance && (
-            <div style={{ marginTop: "16px", paddingTop: "14px", borderTop: "1px solid color-mix(in srgb, var(--color-ink) 8%, transparent)" }}>
-              <span className="font-mono" style={{ fontSize: "11px", color: "var(--color-muted)", letterSpacing: "0.06em", textTransform: "uppercase" }}>
-                {t("governanceFound")}
-              </span>
-              <ul style={{ fontSize: "13px", margin: "6px 0 0", paddingLeft: "16px", listStyle: "disc" }}>
-                {extraction.governance.reserveTargetHUF != null && (
-                  <li>{t("govReserve", { amount: nf.format(extraction.governance.reserveTargetHUF) })}</li>
-                )}
-                {extraction.governance.defaultMajority && (
-                  <li>{t("govMajority")}: {extraction.governance.defaultMajority}</li>
-                )}
-                {extraction.governance.costAllocationBasis && (
-                  <li>{t("govCostBasis")}: {extraction.governance.costAllocationBasis}</li>
-                )}
-              </ul>
-              <div className="flex flex-wrap items-center gap-3" style={{ marginTop: "10px" }}>
-                <button
-                  type="button"
-                  onClick={handleApplyGovernance}
-                  disabled={busy !== "idle"}
-                  className="transition-opacity hover:opacity-90 disabled:opacity-50"
-                  style={{ padding: "9px 14px", borderRadius: "8px", fontSize: "13px", fontWeight: 600, background: "var(--color-card)", color: "var(--color-ink)", border: "1px solid color-mix(in srgb, var(--color-ink) 12%, transparent)" }}
-                >
-                  {busy === "gov" ? t("applying") : t("applyGovCta")}
-                </button>
-                {govMsg && <span style={{ fontSize: "13px", color: "var(--color-ink-soft)" }}>{govMsg}</span>}
-              </div>
-            </div>
-          )}
+          <p style={{ fontSize: "12px", color: "var(--color-moss)", margin: "8px 0 0" }}>
+            {extraction.stored ? `✓ ${t("stored")}` : ""} {t("reviewNext")}
+          </p>
         </div>
       )}
     </div>
   );
-}
-
-function Th({ children }: { children: React.ReactNode }) {
-  return (
-    <th className="font-mono" style={{ padding: "7px 10px", fontSize: "10px", color: "var(--color-muted)", letterSpacing: "0.05em", textTransform: "uppercase", fontWeight: 600 }}>
-      {children}
-    </th>
-  );
-}
-function Td({ children }: { children: React.ReactNode }) {
-  return <td style={{ padding: "6px 10px" }}>{children}</td>;
 }
 
 function fileToBase64(file: File): Promise<string> {

--- a/src/components/units/import-units-button.tsx
+++ b/src/components/units/import-units-button.tsx
@@ -42,7 +42,7 @@ const unitsImportConfig: ImportConfig = {
   ],
 };
 
-export function ImportUnitsButton() {
+export function ImportUnitsButton({ onImported }: { onImported?: () => void } = {}) {
   const t = useTranslations("import");
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -50,6 +50,7 @@ export function ImportUnitsButton() {
   async function handleImport(rows: ImportRow[]): Promise<ImportResult> {
     const result = await importUnits(rows);
     router.refresh();
+    if (result.created > 0) onImported?.();
     return result;
   }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2990,11 +2990,16 @@
       "statusDetail": "Upload the SZMSZ and the founding deed.",
       "openDocuments": "Open documents"
     },
+    "prefilledFromSzmsz": "Pre-filled from the SZMSZ — review before saving.",
     "ai": {
       "eyebrow": "AI fill",
       "title": "Fill from the SZMSZ",
-      "subtitle": "Upload an SZMSZ / founding-deed PDF and AI reads out the units and governance settings. You review every proposal before it is applied.",
+      "subtitle": "Upload an SZMSZ / founding-deed PDF and AI reads out the units and governance settings. You review and commit the units and settings in the next steps.",
       "uploadCta": "Upload SZMSZ PDF",
+      "reupload": "Upload a different PDF",
+      "summaryUnits": "{count} units detected · Σ {pct}% ownership share",
+      "stored": "SZMSZ saved to Documents.",
+      "reviewNext": "Review and commit in the next steps.",
       "extracting": "Processing…",
       "gdprNote": "An SZMSZ may contain personal data. The uploaded PDF is processed by an AI provider; review the proposals before saving.",
       "notPdf": "Only PDF files can be uploaded.",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -2990,11 +2990,16 @@
       "statusDetail": "Töltsd fel az SZMSZ-t és az alapító okiratot.",
       "openDocuments": "Dokumentumok megnyitása"
     },
+    "prefilledFromSzmsz": "Az SZMSZ-ből előkitöltve — ellenőrizd, mielőtt mented.",
     "ai": {
       "eyebrow": "AI kitöltés",
       "title": "Kitöltés az SZMSZ-ből",
-      "subtitle": "Tölts fel egy SZMSZ / alapító okirat PDF-et, és az AI kiolvassa az albetéteket és az önkormányzási beállításokat. Minden javaslatot te hagysz jóvá.",
+      "subtitle": "Tölts fel egy SZMSZ / alapító okirat PDF-et, és az AI kiolvassa az albetéteket és az önkormányzási beállításokat. Az albetéteket és a beállításokat a következő lépésekben ellenőrizheted és rögzítheted.",
       "uploadCta": "SZMSZ PDF feltöltése",
+      "reupload": "Másik PDF feltöltése",
+      "summaryUnits": "{count} albetét felismerve · Σ {pct}% tulajdoni hányad",
+      "stored": "SZMSZ elmentve a Dokumentumokhoz.",
+      "reviewNext": "Ellenőrizd és rögzítsd a következő lépésekben.",
       "extracting": "Feldolgozás…",
       "gdprNote": "Az SZMSZ személyes adatokat tartalmazhat. A feltöltött PDF-et AI-szolgáltató dolgozza fel; a javaslatokat mentés előtt ellenőrizd.",
       "notPdf": "Csak PDF fájl tölthető fel.",


### PR DESCRIPTION
Addresses the issues found while manually testing the onboarding flow.

## Changes

**Flow restructure (your points 2 & 3 — redundant steps):**
- Reordered to **SZMSZ-first**: `basics → SZMSZ → units → governance → invites → review`.
- The AI extraction now **pre-fills the Units and Governance steps** — no duplicate entry. The Units step shows the extracted units for review/commit; the Governance step is pre-filled (with a "pre-filled from SZMSZ — review" note).

**Bug fixes:**
1. **Units import didn't update until reload** → the import now refreshes the wizard immediately, for both the AI-extracted import and the manual `ImportUnitsButton` (new `onImported` callback).
4. **Raw enum labels** in the AI summary (`SIMPLE_MAJORITY`) → now translated (*Egyszerű többség*, *Tulajdoni hányad szerint*).
5. **"Settings applied" but 0 documents** → the uploaded SZMSZ PDF is now **stored as a document** in the Bylaws category (via the `board.manage`-gated extract endpoint, since board members lack general publish rights). The doc count + "first document" step update live.
6. **Re-upload on every step change** → the extraction result is **lifted to the wizard**, so it survives step navigation — upload/process once.

## Validation

Full end-to-end on a fresh registered building (over tailnet dev): SZMSZ upload → **10 units + governance extracted, labels translated, PDF stored (doc count → 1)** → units **pre-fill the next step** and import to **100%** (status flips live, no reload) → governance **pre-filled** (8M / simple majority / ownership share) → finish. DB verified: address, reserve 8M, 10 units @ 1.0000, onboarded, 1 document. No console errors; `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)