### PR TITLE
fix(register): founding user is building ADMIN, not board member

### DIFF
--- a/src/lib/register.ts
+++ b/src/lib/register.ts
@@ -133,7 +133,10 @@ export async function register(rawInput: unknown, baseUrl: string): Promise<Regi
         data: {
           userId: user.id,
           buildingId: building.id,
-          role: "BOARD_MEMBER",
+          // The person who registers a building is its administrator (közös
+          // képviselő): they run onboarding, manage users/residents and assign
+          // owners to units — all of which require ADMIN (users.manage).
+          role: "ADMIN",
           isActive: true,
         },
       });


### PR DESCRIPTION
## Bug

Registering a building assigned the founder the **`BOARD_MEMBER`** role. But inviting residents and assigning owners to units require **`users.manage`**, which is **ADMIN-only**:

```
case "users.manage": return actor.role === "ADMIN";
```

So the person who registers a building — the közös képviselő / administrator — couldn't complete onboarding: the "assign owners to units" step sends them to `/residents`, where their role has no permission to invite or assign. Dead end.

## Fix

The founding `UserBuilding` gets **`role: "ADMIN"`** (matching the demo `admin@condo.local`). Correct domain model — the building creator is its administrator — and it unblocks the whole onboarding flow. Still satisfies the wizard's `board.manage` gate.

## Validation

Live (tailnet dev): registered a fresh building → founder's role is **ADMIN** (DB-verified) → as that user, sending a resident invitation (role Tulajdonos) **succeeded** and created an `OWNER`/`PENDING` invitation (previously 403 for a board member). `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)