### PR TITLE
feat(authz): enforce per-member board-permission grants in can()

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import { authOptions } from "./auth-options";
+import { prisma } from "./prisma";
 
 export const { handlers, auth, signIn, signOut } = NextAuth(authOptions);
 
@@ -25,10 +26,27 @@ export async function requireBuildingContext() {
   const buildingId = imp?.buildingId ?? user.activeBuildingId;
   if (!buildingId) throw new Error("No building selected");
 
+  const userId = imp?.userId ?? user.id;
+  const role = imp?.role ?? user.activeRole;
+
+  // Board-permission grants are additive delegation (per-resident editor).
+  // Load fresh (not from the session) so an admin's toggle applies immediately,
+  // and only for BOARD_MEMBER — ADMIN/SUPER_ADMIN already hold these caps and
+  // OWNER/TENANT are never granted board permissions.
+  let grants: string[] = [];
+  if (role === "BOARD_MEMBER") {
+    const rows = await prisma.userBuildingPermission.findMany({
+      where: { userBuilding: { userId, buildingId } },
+      select: { permission: { select: { key: true } } },
+    });
+    grants = rows.map((r) => r.permission.key);
+  }
+
   return {
-    userId: imp?.userId ?? user.id,
+    userId,
     buildingId,
-    role: imp?.role ?? user.activeRole,
+    role,
+    grants,
     // ActorContext flags — already hydrated into the session (auth-options.ts).
     // Enables can(actor, capability) at call-sites without extra DB lookups.
     isChair: (imp ? imp.isChair : user.isChair) ?? false,

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -31,6 +31,8 @@ export interface BuildingActor {
   ownsAnyUnit?: boolean;
   isAuditor?: boolean;
   isProfessional?: boolean;
+  /** Explicit board-permission grant keys for the active building. */
+  grants?: readonly string[];
 }
 
 /** Build a typed ActorContext from a building context. */
@@ -41,6 +43,7 @@ export function actorFrom(ctx: BuildingActor): ActorContext {
     ownsAnyUnit: ctx.ownsAnyUnit,
     isAuditor: ctx.isAuditor,
     isProfessional: ctx.isProfessional,
+    grants: ctx.grants,
   };
 }
 

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -109,7 +109,30 @@ export interface ActorContext {
    *  their units. Never gate privilege on this; Tht. has no legal
    *  distinction between "rezidens" and "távoli tulajdonos". */
   livesAtUnit?: boolean;
+  /** BoardPermission keys explicitly granted to this member for the active
+   *  building (the per-resident "permissions" editor). Additive delegation —
+   *  a grant can unlock an operational capability the base role lacks. See
+   *  GRANT_UNLOCKS. Loaded per-request in requireBuildingContext(). */
+  grants?: readonly string[];
 }
+
+/**
+ * Maps a delegatable capability → the BoardPermission grant key that unlocks
+ * it. A board member holding the grant gets the capability even though their
+ * base role wouldn't. Additive only — never removes access. Grants without a
+ * clean capability target (edit_resident_contact, delete_resident,
+ * modify_bylaws) are intentionally not wired: each would need a dedicated
+ * capability + gating on the underlying action.
+ */
+const GRANT_UNLOCKS: Partial<Record<Capability, string>> = {
+  "manage.budget": "financial_full",
+  "view.building.finance": "financial_full",
+  "approve.invoice": "invoice_signoff",
+  "announcement.publish": "board_post",
+  "announcement.boardChannel": "board_post",
+  "vote.start": "vote_create",
+  "ticket.assign": "maintenance_orders",
+};
 
 export function can(
   actor: ActorContext,
@@ -120,6 +143,14 @@ export function can(
   // building-legal powers without the explicit impersonation flow.
   if (actor.role === "SUPER_ADMIN") {
     return SUPER_ADMIN_CAPS.has(cap);
+  }
+
+  // Additive delegation: an explicit board-permission grant unlocks the mapped
+  // operational capability regardless of what the base role allows. Returns
+  // true only — it can never reduce access below the role baseline below.
+  if (actor.grants && actor.grants.length > 0) {
+    const grantKey = GRANT_UNLOCKS[cap];
+    if (grantKey && actor.grants.includes(grantKey)) return true;
   }
 
   // Representative authority — Tht. § 43. Either the sole közös

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -783,10 +783,12 @@ export interface DashboardContext {
   ownsAnyUnit: boolean;
   isAuditor: boolean;
   isProfessional: boolean;
+  /** Board-permission grants — so page-level allows() honors delegation. */
+  grants: readonly string[];
 }
 
 export const getDashboardContext = cache(async (): Promise<DashboardContext> => {
-  const { role, isChair, ownsAnyUnit, isAuditor, isProfessional } =
+  const { role, isChair, ownsAnyUnit, isAuditor, isProfessional, grants } =
     await requireBuildingContext();
   // Get user name from session
   const { getCurrentUser } = await import("@/lib/auth");
@@ -798,6 +800,7 @@ export const getDashboardContext = cache(async (): Promise<DashboardContext> => 
     ownsAnyUnit,
     isAuditor,
     isProfessional,
+    grants,
   };
 });
 

--- a/tests/lib/capabilities.test.ts
+++ b/tests/lib/capabilities.test.ts
@@ -243,3 +243,44 @@ describe("can() — governance: users.assignRole (relational escalation)", () =>
     expect(can(actor({ role: "OWNER" }), "users.assignRole", { targetRole: "TENANT" })).toBe(false);
   });
 });
+
+describe("can() — additive board-permission grants", () => {
+  it("a plain BOARD_MEMBER lacks the delegatable operational caps", () => {
+    const bm = actor({ role: "BOARD_MEMBER" });
+    expect(can(bm, "manage.budget")).toBe(false);
+    expect(can(bm, "approve.invoice")).toBe(false);
+    expect(can(bm, "vote.start")).toBe(false);
+    expect(can(bm, "announcement.publish")).toBe(false);
+    expect(can(bm, "ticket.assign")).toBe(false);
+  });
+
+  it("a matching grant unlocks the mapped capability", () => {
+    expect(can(actor({ role: "BOARD_MEMBER", grants: ["financial_full"] }), "manage.budget")).toBe(true);
+    expect(can(actor({ role: "BOARD_MEMBER", grants: ["invoice_signoff"] }), "approve.invoice")).toBe(true);
+    expect(can(actor({ role: "BOARD_MEMBER", grants: ["vote_create"] }), "vote.start")).toBe(true);
+    expect(can(actor({ role: "BOARD_MEMBER", grants: ["maintenance_orders"] }), "ticket.assign")).toBe(true);
+    // board_post covers both announcement caps
+    const poster = actor({ role: "BOARD_MEMBER", grants: ["board_post"] });
+    expect(can(poster, "announcement.publish")).toBe(true);
+    expect(can(poster, "announcement.boardChannel")).toBe(true);
+  });
+
+  it("a grant only unlocks its own capability, not others", () => {
+    const financeOnly = actor({ role: "BOARD_MEMBER", grants: ["financial_full"] });
+    expect(can(financeOnly, "manage.budget")).toBe(true);
+    expect(can(financeOnly, "vote.start")).toBe(false);
+    expect(can(financeOnly, "approve.invoice")).toBe(false);
+  });
+
+  it("unmapped grant keys (delete_resident, modify_bylaws) do not unlock caps", () => {
+    const a = actor({ role: "BOARD_MEMBER", grants: ["delete_resident", "modify_bylaws"] });
+    expect(can(a, "users.manage")).toBe(false);
+    expect(can(a, "document.publish.public")).toBe(false);
+  });
+
+  it("grants never reduce access below the role baseline", () => {
+    // ADMIN keeps everything even with no grants passed.
+    expect(can(actor({ role: "ADMIN" }), "manage.budget")).toBe(true);
+    expect(can(actor({ role: "ADMIN", grants: [] }), "approve.invoice")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Answering "why are all the permission toggles off?": those toggles wrote `BoardPermission` grants, but **nothing consulted them** — `can()` decided purely from role, so the editor was **cosmetic**. (An ADMIN sees them all off yet has everything via role; toggling did nothing.)

## What

Wire the grants in as **additive delegation**: a board member holding a grant gains the mapped operational capability even though their base role wouldn't allow it. Additive only — it can never reduce access below the role baseline.

- **`capabilities.ts`** — `ActorContext.grants` + a `GRANT_UNLOCKS` map:
  - `financial_full` → `manage.budget`, `view.building.finance`
  - `invoice_signoff` → `approve.invoice`
  - `board_post` → `announcement.publish`, `announcement.boardChannel`
  - `vote_create` → `vote.start`
  - `maintenance_orders` → `ticket.assign`
- **`auth.ts`** — `requireBuildingContext` loads the granted keys **fresh** for `BOARD_MEMBER` (not from the session, so an admin's toggle applies immediately; skipped for ADMIN/SUPER_ADMIN who already hold these caps).
- **`authz.ts` + `dal.ts`** — thread `grants` through `actorFrom` + `getDashboardContext`, so page-level `allows()` honors delegation too (e.g. the `/voting` "new vote" affordance appears for a granted board member).

## Not wired (intentional)

`edit_resident_contact`, `delete_resident`, `modify_bylaws` have no clean capability target — they'd each need a dedicated capability + gating on the underlying action. They remain display-only for now (documented in a code comment).

## Validation

- **5 new unit tests**: plain board member lacks the caps; each grant unlocks its mapped cap; grants don't cross-unlock; unmapped keys don't unlock; grants never reduce the role baseline. **297 tests pass**.
- Confirmed the grant-loading query returns the key against the real DB. `tsc` + `eslint` clean.
- (Full browser click-through was blocked by a stuck NextAuth signout in the off-machine test browser — an env quirk, not a product issue; each link of the chain is unit-tested / type-verified / DB-verified.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)