### PR TITLE
chore(permissions): drop edit_resident_contact board permission

### DIFF
--- a/prisma/migrations/20260701134252_remove_edit_resident_contact_permission/migration.sql
+++ b/prisma/migrations/20260701134252_remove_edit_resident_contact_permission/migration.sql
@@ -1,0 +1,6 @@
+-- Drop the "edit_resident_contact" board permission: residents edit their own
+-- contact details (profile), so board-side contact editing isn't needed. Also
+-- removes any grants of it. Data-only migration (no schema change).
+DELETE FROM "UserBuildingPermission"
+  WHERE "permissionId" IN (SELECT "id" FROM "BoardPermission" WHERE "key" = 'edit_resident_contact');
+DELETE FROM "BoardPermission" WHERE "key" = 'edit_resident_contact';

--- a/prisma/seed-demo.ts
+++ b/prisma/seed-demo.ts
@@ -1351,7 +1351,6 @@ const BOARD_PERM_KEYS = [
   "invoice_signoff",
   "board_post",
   "vote_create",
-  "edit_resident_contact",
   "maintenance_orders",
 ];
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1352,7 +1352,6 @@ const BOARD_PERMISSIONS = [
   { key: "invoice_signoff", labelKey: "perm.invoice_signoff.label", descriptionKey: "perm.invoice_signoff.desc", default: true },
   { key: "board_post", labelKey: "perm.board_post.label", descriptionKey: "perm.board_post.desc", default: true },
   { key: "vote_create", labelKey: "perm.vote_create.label", descriptionKey: "perm.vote_create.desc", default: true },
-  { key: "edit_resident_contact", labelKey: "perm.edit_resident_contact.label", descriptionKey: "perm.edit_resident_contact.desc", default: true },
   { key: "maintenance_orders", labelKey: "perm.maintenance_orders.label", descriptionKey: "perm.maintenance_orders.desc", default: true },
   { key: "delete_resident", labelKey: "perm.delete_resident.label", descriptionKey: "perm.delete_resident.desc", default: false },
   { key: "modify_bylaws", labelKey: "perm.modify_bylaws.label", descriptionKey: "perm.modify_bylaws.desc", default: false },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -607,10 +607,6 @@
         "label": "Start a vote",
         "desc": "All types"
       },
-      "edit_resident_contact": {
-        "label": "Edit resident contact",
-        "desc": "Contact fields only"
-      },
       "maintenance_orders": {
         "label": "Maintenance orders",
         "desc": "Per partner contract"

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -607,10 +607,6 @@
         "label": "Szavazás indítása",
         "desc": "Minden típus"
       },
-      "edit_resident_contact": {
-        "label": "Lakó adatainak szerkesztése",
-        "desc": "Csak kapcsolat mezők"
-      },
       "maintenance_orders": {
         "label": "Karbantartás megrendelés",
         "desc": "Partner szerződés alapján"


### PR DESCRIPTION
Per follow-up decision: residents edit their **own** contact details (profile), so a board-side "edit resident contact" grant isn't needed — and there was no contact-edit surface behind it anyway (it was one of the display-only toggles).

- Removed from the seed catalog (`seed.ts` + `seed-demo.ts`).
- Data migration deletes the `BoardPermission` row + any grants of it from existing DBs.
- Dropped the orphaned `perm.edit_resident_contact.*` i18n labels.

No capability was ever mapped to it (it stayed display-only), so nothing in `can()` changes.

_Part of building out the three previously-cosmetic toggles; the other two (delete resident, modify bylaws) are being built as real workflows in follow-up PRs._

🤖 Generated with [Claude Code](https://claude.com/claude-code)