### PR TITLE
feat(residents): dual-control resident removal UI

### DIFF
--- a/src/components/residents/resident-removal-controls.tsx
+++ b/src/components/residents/resident-removal-controls.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import type { ResidentProfileData } from "@/lib/residents-dal";
+import {
+  requestResidentRemoval,
+  reviewResidentRemoval,
+  cancelResidentRemoval,
+} from "@/app/actions/resident-removal";
+
+/**
+ * Dual-control resident removal controls in the profile panel. Initiates a
+ * removal (with reason) when none is pending; when one is pending, a DIFFERENT
+ * board member can approve/reject, and the initiator can cancel.
+ */
+export function ResidentRemovalControls({
+  profile,
+  onChanged,
+}: {
+  profile: ResidentProfileData;
+  onChanged: () => void;
+}) {
+  const t = useTranslations("residents.removal");
+  const router = useRouter();
+  const [reasonOpen, setReasonOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const {
+    canRemove,
+    isActive,
+    isCurrentUser,
+    role,
+    pendingRemoval,
+    currentUserId,
+    userBuildingId,
+    name,
+  } = profile;
+
+  if (!canRemove) return null;
+
+  const isAdminTarget = role === "ADMIN" || role === "SUPER_ADMIN";
+
+  async function run(fn: () => Promise<{ success?: boolean; error?: string }>) {
+    setBusy(true);
+    try {
+      const res = await fn();
+      if (res.error) {
+        toast.error(res.error);
+        return;
+      }
+      onChanged();
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // ── A removal is pending ──────────────────────────────────────────────
+  if (pendingRemoval) {
+    const isInitiator = pendingRemoval.requestedById === currentUserId;
+    return (
+      <div style={cardStyle("ochre")}>
+        <div style={{ fontSize: "12px", fontWeight: 700, color: "var(--color-ochre)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+          {t("pendingTitle")}
+        </div>
+        <p style={{ fontSize: "13px", color: "var(--color-ink-soft)", margin: "6px 0 0" }}>
+          {t("pendingBy", { name: pendingRemoval.requesterName })}
+        </p>
+        <p style={{ fontSize: "13px", margin: "4px 0 0" }}>“{pendingRemoval.reason}”</p>
+        <div className="flex flex-wrap gap-2" style={{ marginTop: "12px" }}>
+          {isInitiator ? (
+            <>
+              <span style={{ fontSize: "12px", color: "var(--color-muted)", alignSelf: "center" }}>
+                {t("awaitingApproval")}
+              </span>
+              <button type="button" disabled={busy} style={ghostBtn} onClick={() => run(() => cancelResidentRemoval({ requestId: pendingRemoval.id }))}>
+                {t("cancel")}
+              </button>
+            </>
+          ) : (
+            <>
+              <button type="button" disabled={busy} style={dangerBtn} onClick={() => run(() => reviewResidentRemoval({ requestId: pendingRemoval.id, approve: true }))}>
+                {t("approve")}
+              </button>
+              <button type="button" disabled={busy} style={ghostBtn} onClick={() => run(() => reviewResidentRemoval({ requestId: pendingRemoval.id, approve: false }))}>
+                {t("reject")}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Already removed / not removable ───────────────────────────────────
+  if (!isActive) {
+    return (
+      <div style={cardStyle("muted")}>
+        <span style={{ fontSize: "12px", color: "var(--color-muted)" }}>{t("removed")}</span>
+      </div>
+    );
+  }
+  if (isCurrentUser || isAdminTarget) return null;
+
+  // ── Initiate ──────────────────────────────────────────────────────────
+  return (
+    <div style={cardStyle()}>
+      {!reasonOpen ? (
+        <button type="button" style={dangerGhostBtn} onClick={() => setReasonOpen(true)}>
+          {t("removeCta")}
+        </button>
+      ) : (
+        <div>
+          <label style={{ fontSize: "12px", fontWeight: 600 }}>{t("reasonLabel", { name })}</label>
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={2}
+            placeholder={t("reasonPlaceholder")}
+            style={{ width: "100%", marginTop: "6px", padding: "8px 10px", borderRadius: "8px", fontSize: "13px", border: "1px solid color-mix(in srgb, var(--color-ink) 15%, transparent)", background: "var(--color-bg)", color: "var(--color-ink)", resize: "vertical" }}
+          />
+          <p className="font-mono" style={{ fontSize: "10.5px", color: "var(--color-muted)", margin: "6px 0 0", letterSpacing: "0.02em" }}>
+            {t("dualControlNote")}
+          </p>
+          <div className="flex gap-2" style={{ marginTop: "10px" }}>
+            <button
+              type="button"
+              disabled={busy || reason.trim().length === 0}
+              style={{ ...dangerBtn, opacity: reason.trim().length === 0 ? 0.5 : 1 }}
+              onClick={() =>
+                run(async () => {
+                  const r = await requestResidentRemoval({ targetUserBuildingId: userBuildingId, reason });
+                  if (r.success) { setReasonOpen(false); setReason(""); }
+                  return r;
+                })
+              }
+            >
+              {t("submitRequest")}
+            </button>
+            <button type="button" disabled={busy} style={ghostBtn} onClick={() => { setReasonOpen(false); setReason(""); }}>
+              {t("cancel")}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function cardStyle(accent?: "ochre" | "muted"): React.CSSProperties {
+  const border =
+    accent === "ochre"
+      ? "color-mix(in srgb, var(--color-ochre) 35%, transparent)"
+      : "color-mix(in srgb, var(--color-ink) 10%, transparent)";
+  return {
+    marginTop: "14px",
+    padding: "14px 16px",
+    borderRadius: "12px",
+    border: `1px solid ${border}`,
+    background: accent === "ochre" ? "color-mix(in srgb, var(--color-ochre) 6%, transparent)" : "var(--color-card)",
+  };
+}
+
+const dangerBtn: React.CSSProperties = {
+  padding: "8px 14px", borderRadius: "8px", fontSize: "13px", fontWeight: 600,
+  background: "var(--color-danger)", color: "#fff", border: "none", cursor: "pointer",
+};
+const dangerGhostBtn: React.CSSProperties = {
+  padding: "8px 14px", borderRadius: "8px", fontSize: "13px", fontWeight: 600,
+  background: "transparent", color: "var(--color-danger)",
+  border: "1px solid color-mix(in srgb, var(--color-danger) 40%, transparent)", cursor: "pointer",
+};
+const ghostBtn: React.CSSProperties = {
+  padding: "8px 14px", borderRadius: "8px", fontSize: "13px", fontWeight: 600,
+  background: "var(--color-card)", color: "var(--color-ink)",
+  border: "1px solid color-mix(in srgb, var(--color-ink) 12%, transparent)", cursor: "pointer",
+};

--- a/src/components/residents/residents-explorer.tsx
+++ b/src/components/residents/residents-explorer.tsx
@@ -9,6 +9,7 @@ import type {
   ResidentsRoleDistribution,
 } from "@/lib/residents-dal";
 import { PermissionsEditorModal } from "./permissions-editor-modal";
+import { ResidentRemovalControls } from "./resident-removal-controls";
 
 interface Props {
   isBoardPlus: boolean;
@@ -44,6 +45,7 @@ export function ResidentsExplorer({ groups, distribution, tabCounts, isAdmin }: 
   });
   const [profile, setProfile] = useState<ResidentProfileData | null>(null);
   const [loadingProfile, setLoadingProfile] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
     if (!selectedId) {
@@ -64,7 +66,7 @@ export function ResidentsExplorer({ groups, distribution, tabCounts, isAdmin }: 
     return () => {
       cancelled = true;
     };
-  }, [selectedId]);
+  }, [selectedId, refreshKey]);
 
   // Filter groups by sub-tab + search
   const visibleGroups = groups
@@ -212,6 +214,7 @@ export function ResidentsExplorer({ groups, distribution, tabCounts, isAdmin }: 
           profile={profile}
           loading={loadingProfile}
           isAdmin={isAdmin}
+          onChanged={() => setRefreshKey((k) => k + 1)}
         />
       </div>
     </>
@@ -538,10 +541,12 @@ function ProfilePanel({
   profile,
   loading,
   isAdmin,
+  onChanged,
 }: {
   profile: ResidentProfileData | null;
   loading: boolean;
   isAdmin: boolean;
+  onChanged: () => void;
 }) {
   const t = useTranslations("residents");
   const [permsOpen, setPermsOpen] = useState(false);
@@ -856,6 +861,7 @@ function ProfilePanel({
             </button>
           </div>
         )}
+        <ResidentRemovalControls profile={profile} onChanged={onChanged} />
       </div>
       <PermissionsEditorModal
         open={permsOpen}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -154,6 +154,20 @@
       "outstanding": "Outstanding",
       "activity": "Activity"
     },
+    "removal": {
+      "removeCta": "Remove resident",
+      "reasonLabel": "Reason for removing {name}",
+      "reasonPlaceholder": "e.g. moved out, ownership transferred…",
+      "dualControlNote": "Approval requires confirmation by a second board member.",
+      "submitRequest": "Submit request",
+      "cancel": "Cancel",
+      "pendingTitle": "Removal awaiting approval",
+      "pendingBy": "Initiated by {name}",
+      "awaitingApproval": "Waiting for another board member to approve.",
+      "approve": "Approve",
+      "reject": "Reject",
+      "removed": "This resident has been removed (inactive)."
+    },
     "permissions": {
       "managerCta": "Edit permissions",
       "eyebrow": "/ admin · permissions",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -154,6 +154,20 @@
       "outstanding": "Hátralék",
       "activity": "Aktivitás"
     },
+    "removal": {
+      "removeCta": "Lakó eltávolítása",
+      "reasonLabel": "{name} eltávolításának indoka",
+      "reasonPlaceholder": "Pl. elköltözött, tulajdonos-váltás…",
+      "dualControlNote": "A jóváhagyáshoz egy másik intézőbizottsági tag megerősítése szükséges.",
+      "submitRequest": "Kérelem beküldése",
+      "cancel": "Mégse",
+      "pendingTitle": "Eltávolítás jóváhagyásra vár",
+      "pendingBy": "Kezdeményezte: {name}",
+      "awaitingApproval": "Másik tag jóváhagyására vár.",
+      "approve": "Jóváhagyás",
+      "reject": "Elutasítás",
+      "removed": "Ez a lakó el lett távolítva (inaktív)."
+    },
     "permissions": {
       "managerCta": "Jogosultság szerkeszt",
       "eyebrow": "/ admin · jogosultság",

--- a/src/lib/residents-dal.ts
+++ b/src/lib/residents-dal.ts
@@ -118,6 +118,22 @@ export interface ResidentProfileData {
     sub: string | null;
   }[];
   isBoardPlus: boolean;
+  // ── Dual-control removal ──────────────────────────────────────────────
+  /** The membership id — target of a removal request. */
+  userBuildingId: string;
+  /** False once a removal has been approved (soft-removed). */
+  isActive: boolean;
+  /** Whether the viewer may initiate/approve removals (resident.remove). */
+  canRemove: boolean;
+  /** The viewer's user id — to enforce two-person control in the UI. */
+  currentUserId: string;
+  /** An open removal request for this resident, if any. */
+  pendingRemoval: {
+    id: string;
+    requestedById: string;
+    requesterName: string;
+    reason: string;
+  } | null;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -564,7 +580,32 @@ export const getResidentProfile = cache(
     // Phase 5 — Tht. § 22(2). Same redaction rule as the directory.
     const exposeContact = primary ? mayExposeContactData(primary) : true;
 
+    // Dual-control removal state for this membership.
+    const canRemove = allows(ctx, "resident.remove");
+    const pending = await prisma.residentRemovalRequest.findFirst({
+      where: { targetUserBuildingId: ub.id, status: "PENDING" },
+      select: { id: true, requestedById: true, reason: true },
+    });
+    let pendingRemoval: ResidentProfileData["pendingRemoval"] = null;
+    if (pending) {
+      const requester = await prisma.user.findUnique({
+        where: { id: pending.requestedById },
+        select: { name: true },
+      });
+      pendingRemoval = {
+        id: pending.id,
+        requestedById: pending.requestedById,
+        requesterName: requester?.name ?? "—",
+        reason: pending.reason,
+      };
+    }
+
     return {
+      userBuildingId: ub.id,
+      isActive: ub.isActive,
+      canRemove,
+      currentUserId: userId,
+      pendingRemoval,
       id: u.id,
       kind: "resident",
       name: u.name,


### PR DESCRIPTION
The UI for the removal engine (#109) — surfaces it in `/residents`.

## What
In the resident profile panel, when the viewer has `resident.remove` (ADMIN, or a board member with the `delete_resident` grant):
- **No pending request** → a **"Remove resident"** action (reason required) for active, non-admin, non-self residents.
- **Pending request** → shows the reason + initiator; a **different** board member gets **Approve / Reject**; the **initiator** sees only **Cancel** (two-person control enforced in the UI, not just the server).
- After any action the panel refetches.

`getResidentProfile` now returns `userBuildingId` / `isActive` / `canRemove` / `currentUserId` / `pendingRemoval`.

## Validation (live, tailnet)
As a board member (Szabó Péter, chair) granted `delete_resident`: the **"Lakó eltávolítása" button appeared** (proving grant→capability→UI end-to-end) → initiated with a reason → the **pending panel** rendered "awaiting approval" with only **Cancel** (no Approve, since he's the initiator). Console clean; test data cleaned up afterward. `tsc` + `eslint` clean; the engine's 8 integration tests cover the approve/reject/guard logic.

## Next
The assembly-resolution **bylaws** workflow (tied to an in-app vote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)