### PR TITLE
ci: prune dangling images after deploy to stop disk fill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,12 @@ jobs:
             docker compose pull
             docker compose run --rm worker npx prisma migrate deploy
             docker compose up -d
+            # Rolling to the new :latest leaves the previous app/worker images
+            # untagged (dangling). Prune them now — otherwise they accumulate and
+            # fill the disk (they once grew to 70 images / ~90GB and took the
+            # server down). Only dangling images are removed, so images still in
+            # use by Home Assistant, the monitoring stack, etc. are untouched.
+            docker image prune -f
             curl -sS -o /dev/null -w "health: HTTP %{http_code}\n" \
               --retry 10 --retry-delay 3 --retry-all-errors http://localhost:3000
           '


### PR DESCRIPTION
## What
Add `docker image prune -f` to the deploy step, right after `docker compose up -d`.

## Why
Each deploy rolls the app/worker containers onto the new `:latest`, leaving the previous images untagged (**dangling**). Nothing ever removed them, so they piled up to **~70 images / ~90 GB** and filled the server's root disk to **100% on 2026-06-30** — causing an unclean reboot and a Postgres crash-loop (`No space left on device`). Manual cleanup reclaimed ~20 GB and brought the disk back to 30%.

## How it's safe
The prune runs *after* the new containers are up, so the superseded images are already unreferenced. `prune -f` removes **dangling images only** — Home Assistant, the monitoring stack, and every other tagged/in-use image on that shared box are untouched.

## Not covered (follow-up)
- The immutable `sha-…` tags still accumulate in **GHCR** (registry storage, not the server disk) — slower, non-fatal; a retention policy can trim those later.
- The `HostDiskAlmostFull` Prometheus alert already exists but **isn't delivered anywhere** (no Alertmanager). Wiring up notification is the real safety net against the *next* cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)