### PR TITLE
feat(bylaws): governance changes via assembly resolution (engine)

### DIFF
--- a/docs/data-model.dbml
+++ b/docs/data-model.dbml
@@ -164,6 +164,7 @@ may require a stricter rule for specific decisions.']
   generatedReports GeneratedReport [not null]
   featureOverrides BuildingFeatureOverride [not null, note: 'Superadmin feature console — per-building feature grant/revoke overrides.']
   residentRemovalRequests ResidentRemovalRequest [not null]
+  bylawsChangeProposals BylawsChangeProposal [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
 }
@@ -1290,6 +1291,24 @@ Table Vote {
 publication whose bids are the options. On close, the winning option\'s
 bid is awarded automatically. Null for ordinary votes.']
   linkedPublicationId String
+  linkedBylawsProposal BylawsChangeProposal [note: 'Set when this vote backs a bylaws/governance change (assembly resolution):
+on close-as-passed the proposal\'s changeset is applied to the Building.']
+  linkedBylawsProposalId String [unique]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+}
+
+Table BylawsChangeProposal {
+  id String [pk]
+  building Building [not null]
+  buildingId String [not null]
+  proposedById String [not null, note: 'Board-level user who proposed it (User id — no FK, to avoid User churn).']
+  reserveTargetHUF BigInt [note: 'Proposed values — only the non-null fields are applied on approval.']
+  defaultMajority MajorityType
+  costAllocationBasis CostAllocationBasis
+  status BylawsProposalStatus [not null, default: 'PENDING_VOTE']
+  vote Vote [note: 'The backing assembly vote (set once created).']
+  appliedAt DateTime
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
 }
@@ -1718,6 +1737,13 @@ Enum MeetingQuestionStatus {
   ADDRESSED
 }
 
+Enum BylawsProposalStatus {
+  PENDING_VOTE
+  APPLIED
+  REJECTED
+  CANCELLED
+}
+
 Enum ReportStatus {
   PENDING
   RUNNING
@@ -1974,6 +2000,10 @@ Ref: Vote.meetingId > Meeting.id
 Ref: Vote.createdById > User.id
 
 Ref: Vote.linkedPublicationId > MarketplacePublication.id
+
+Ref: Vote.linkedBylawsProposalId - BylawsChangeProposal.id
+
+Ref: BylawsChangeProposal.buildingId > Building.id
 
 Ref: VoteOption.voteId > Vote.id [delete: Cascade]
 

--- a/prisma/migrations/20260701150000_bylaws_change_proposals/migration.sql
+++ b/prisma/migrations/20260701150000_bylaws_change_proposals/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "BylawsProposalStatus" AS ENUM ('PENDING_VOTE', 'APPLIED', 'REJECTED', 'CANCELLED');
+
+-- AlterTable
+ALTER TABLE "Building" ALTER COLUMN "representativeRegistryDeadline" SET DEFAULT '2026-10-31 23:59:59+02'::timestamptz;
+
+-- AlterTable
+ALTER TABLE "Vote" ADD COLUMN     "linkedBylawsProposalId" TEXT;
+
+-- CreateTable
+CREATE TABLE "BylawsChangeProposal" (
+    "id" TEXT NOT NULL,
+    "buildingId" TEXT NOT NULL,
+    "proposedById" TEXT NOT NULL,
+    "reserveTargetHUF" BIGINT,
+    "defaultMajority" "MajorityType",
+    "costAllocationBasis" "CostAllocationBasis",
+    "status" "BylawsProposalStatus" NOT NULL DEFAULT 'PENDING_VOTE',
+    "appliedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BylawsChangeProposal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BylawsChangeProposal_buildingId_status_idx" ON "BylawsChangeProposal"("buildingId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Vote_linkedBylawsProposalId_key" ON "Vote"("linkedBylawsProposalId");
+
+-- AddForeignKey
+ALTER TABLE "Vote" ADD CONSTRAINT "Vote_linkedBylawsProposalId_fkey" FOREIGN KEY ("linkedBylawsProposalId") REFERENCES "BylawsChangeProposal"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BylawsChangeProposal" ADD CONSTRAINT "BylawsChangeProposal_buildingId_fkey" FOREIGN KEY ("buildingId") REFERENCES "Building"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -415,6 +415,7 @@ model Building {
   /// Superadmin feature console — per-building feature grant/revoke overrides.
   featureOverrides     BuildingFeatureOverride[]
   residentRemovalRequests ResidentRemovalRequest[]
+  bylawsChangeProposals   BylawsChangeProposal[]
   createdAt            DateTime               @default(now())
   updatedAt            DateTime               @updatedAt
 }
@@ -1881,6 +1882,10 @@ model Vote {
   /// bid is awarded automatically. Null for ordinary votes.
   linkedPublication   MarketplacePublication? @relation("AwardVote", fields: [linkedPublicationId], references: [id])
   linkedPublicationId String?
+  /// Set when this vote backs a bylaws/governance change (assembly resolution):
+  /// on close-as-passed the proposal's changeset is applied to the Building.
+  linkedBylawsProposal   BylawsChangeProposal? @relation("BylawsVote", fields: [linkedBylawsProposalId], references: [id])
+  linkedBylawsProposalId String?               @unique
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 
@@ -1889,6 +1894,36 @@ model Vote {
   @@index([deadline])
   @@index([createdById])
   @@index([linkedPublicationId])
+}
+
+/// A proposed change to the building's bylaws/governance settings. Tht.
+/// requires an assembly resolution for such changes, so the proposal is
+/// backed by a közgyűlés vote and applied only when that vote passes.
+enum BylawsProposalStatus {
+  PENDING_VOTE
+  APPLIED
+  REJECTED
+  CANCELLED
+}
+
+model BylawsChangeProposal {
+  id                  String                @id @default(cuid())
+  building            Building              @relation(fields: [buildingId], references: [id])
+  buildingId          String
+  /// Board-level user who proposed it (User id — no FK, to avoid User churn).
+  proposedById        String
+  /// Proposed values — only the non-null fields are applied on approval.
+  reserveTargetHUF    BigInt?
+  defaultMajority     MajorityType?
+  costAllocationBasis CostAllocationBasis?
+  status              BylawsProposalStatus  @default(PENDING_VOTE)
+  /// The backing assembly vote (set once created).
+  vote                Vote?                 @relation("BylawsVote")
+  appliedAt           DateTime?
+  createdAt           DateTime              @default(now())
+  updatedAt           DateTime              @updatedAt
+
+  @@index([buildingId, status])
 }
 
 model VoteOption {

--- a/src/app/actions/bylaws.ts
+++ b/src/app/actions/bylaws.ts
@@ -1,0 +1,135 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireBuildingContext } from "@/lib/auth";
+import { requireCapability } from "@/lib/authz";
+import { createAuditLog } from "@/lib/audit";
+import { prisma } from "@/lib/prisma";
+import { MajorityType, CostAllocationBasis } from "@prisma/client";
+
+interface ProposeInput {
+  meetingId: string;
+  reserveTargetHUF?: number | null;
+  defaultMajority?: string | null;
+  costAllocationBasis?: string | null;
+  /** Required majority of the backing vote (Tht. bylaws changes: qualified). */
+  voteMajorityType?: string;
+  deadlineISO?: string;
+}
+
+interface ActionResult {
+  success?: boolean;
+  error?: string;
+  proposalId?: string;
+  voteId?: string;
+}
+
+/**
+ * Propose a bylaws/governance change. Creates the proposal + a YES/NO
+ * közgyűlés vote at a meeting; the change is applied automatically only when
+ * that vote closes as passed (resolveBylawsProposal, from the vote-close hook).
+ */
+export async function proposeBylawsChange(input: ProposeInput): Promise<ActionResult> {
+  try {
+    const ctx = await requireBuildingContext();
+    requireCapability(ctx, "bylaws.modify");
+
+    // Validate the changeset — at least one field, each well-formed.
+    const data: {
+      reserveTargetHUF?: bigint;
+      defaultMajority?: MajorityType;
+      costAllocationBasis?: CostAllocationBasis;
+    } = {};
+    if (input.reserveTargetHUF != null) {
+      const n = Number(input.reserveTargetHUF);
+      if (!Number.isFinite(n) || n < 0) return { error: "Invalid reserve target." };
+      data.reserveTargetHUF = BigInt(Math.round(n));
+    }
+    if (input.defaultMajority) {
+      if (!Object.values(MajorityType).includes(input.defaultMajority as MajorityType)) {
+        return { error: "Invalid majority rule." };
+      }
+      data.defaultMajority = input.defaultMajority as MajorityType;
+    }
+    if (input.costAllocationBasis) {
+      if (!Object.values(CostAllocationBasis).includes(input.costAllocationBasis as CostAllocationBasis)) {
+        return { error: "Invalid cost allocation basis." };
+      }
+      data.costAllocationBasis = input.costAllocationBasis as CostAllocationBasis;
+    }
+    if (Object.keys(data).length === 0) {
+      return { error: "Propose at least one change." };
+    }
+
+    const voteMajority: MajorityType =
+      input.voteMajorityType && Object.values(MajorityType).includes(input.voteMajorityType as MajorityType)
+        ? (input.voteMajorityType as MajorityType)
+        : "TWO_THIRDS"; // bylaws default to a qualified majority
+
+    const meeting = await prisma.meeting.findUnique({
+      where: { id: input.meetingId },
+      select: { id: true, buildingId: true, title: true, date: true },
+    });
+    if (!meeting || meeting.buildingId !== ctx.buildingId) {
+      return { error: "Meeting not found." };
+    }
+
+    const deadline = input.deadlineISO ? new Date(input.deadlineISO) : meeting.date;
+
+    const { proposalId, voteId } = await prisma.$transaction(async (tx) => {
+      const proposal = await tx.bylawsChangeProposal.create({
+        data: {
+          buildingId: ctx.buildingId,
+          proposedById: ctx.userId,
+          reserveTargetHUF: data.reserveTargetHUF,
+          defaultMajority: data.defaultMajority,
+          costAllocationBasis: data.costAllocationBasis,
+        },
+      });
+      const vote = await tx.vote.create({
+        data: {
+          title: "SZMSZ / gazdálkodás módosítása",
+          voteType: "YES_NO",
+          status: "OPEN",
+          majorityType: voteMajority,
+          quorumRequired: 0.51, // @deprecated column, kept for compatibility
+          deadline,
+          buildingId: ctx.buildingId,
+          meetingId: meeting.id,
+          createdById: ctx.userId,
+          linkedBylawsProposalId: proposal.id,
+          // YES_NO: first option is "Igen" (the yes weight); then Nem/Tartózkodás.
+          options: {
+            create: [
+              { label: "Igen", sortOrder: 0 },
+              { label: "Nem", sortOrder: 1 },
+              { label: "Tartózkodás", sortOrder: 2 },
+            ],
+          },
+        },
+      });
+      return { proposalId: proposal.id, voteId: vote.id };
+    });
+
+    await createAuditLog({
+      entityType: "BylawsChangeProposal",
+      entityId: proposalId,
+      action: "CREATE",
+      userId: ctx.userId,
+      buildingId: ctx.buildingId,
+      newValue: {
+        voteId,
+        voteMajority,
+        reserveTargetHUF: data.reserveTargetHUF != null ? Number(data.reserveTargetHUF) : undefined,
+        defaultMajority: data.defaultMajority,
+        costAllocationBasis: data.costAllocationBasis,
+      },
+    });
+
+    revalidatePath("/voting");
+    return { success: true, proposalId, voteId };
+  } catch (e) {
+    console.error("proposeBylawsChange failed:", e);
+    return { error: e instanceof Error ? e.message : "Internal error" };
+  }
+}

--- a/src/app/api/voting/votes/[id]/route.ts
+++ b/src/app/api/voting/votes/[id]/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { calculateQuorum, calculateResults, calculateMeetingQuorum, calculateVoteResult } from "@/lib/voting/quorum";
 import { voteUpdated } from "@/lib/voting/events";
 import { resolveAwardVote } from "@/lib/marketplace";
+import { resolveBylawsProposal } from "@/lib/voting/bylaws-proposal";
 import { publishToMeeting } from "@/lib/assembly-bus";
 
 type RouteContext = { params: Promise<{ id: string }> };
@@ -232,6 +233,20 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         award = await resolveAwardVote(id, userId);
       } catch (err) {
         console.error("Auto-award on vote close failed:", err);
+      }
+    }
+
+    // Bylaws resolution: if a governance-change vote just closed, apply the
+    // linked proposal iff it passed. Best-effort — must not fail the close.
+    if (
+      data.status === "CLOSED" &&
+      existing.status !== "CLOSED" &&
+      existing.linkedBylawsProposalId
+    ) {
+      try {
+        await resolveBylawsProposal(id, userId);
+      } catch (err) {
+        console.error("Bylaws resolution on vote close failed:", err);
       }
     }
 

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -64,6 +64,10 @@ export type Capability =
    *  two-person control (distinct initiator + approver) is enforced in the
    *  action, not here. */
   | "resident.remove"
+  /** Propose a bylaws/governance change. Representative authority or ADMIN by
+   *  default; delegatable to a board member via the modify_bylaws grant. The
+   *  change only applies once the backing assembly vote passes. */
+  | "bylaws.modify"
   | "units.manage"
   | "contractor.view"
   | "contractor.manage"
@@ -138,6 +142,7 @@ const GRANT_UNLOCKS: Partial<Record<Capability, string>> = {
   "vote.start": "vote_create",
   "ticket.assign": "maintenance_orders",
   "resident.remove": "delete_resident",
+  "bylaws.modify": "modify_bylaws",
 };
 
 export function can(
@@ -237,6 +242,12 @@ export function can(
       // (handled by the additive GRANT_UNLOCKS check above). Two-person control
       // (distinct initiator + approver) is enforced in the removal action.
       return actor.role === "ADMIN";
+
+    case "bylaws.modify":
+      // Propose a bylaws/governance change (applied only via a passed assembly
+      // vote). Representative authority or ADMIN; a board member gets it via
+      // the modify_bylaws grant (additive check above).
+      return hasRepresentativeAuthority || actor.role === "ADMIN";
 
     case "users.assignRole": {
       // Only ADMIN reaches here (SUPER_ADMIN handled above). An ADMIN may

--- a/src/lib/voting/bylaws-proposal.ts
+++ b/src/lib/voting/bylaws-proposal.ts
@@ -1,0 +1,92 @@
+import { prisma } from "@/lib/prisma";
+import { MajorityType, CostAllocationBasis } from "@prisma/client";
+import { calculateVoteResult } from "@/lib/voting/quorum";
+import { createAuditLog } from "@/lib/audit";
+
+/**
+ * Bylaws change via assembly resolution: a governance change is proposed and
+ * backed by a közgyűlés vote. This applies the change ONLY when that vote
+ * closes as passed (using the vote's majorityType), otherwise marks it
+ * rejected. Mirrors resolveAwardVote — called from the vote-close handler.
+ * Best-effort: a failure here must not fail the vote close.
+ */
+export type ResolveBylawsResult =
+  | { applied: false; reason: "NOT_BYLAWS_VOTE" | "NOT_PENDING" | "REJECTED" }
+  | { applied: true; proposalId: string };
+
+export async function resolveBylawsProposal(
+  voteId: string,
+  closedByUserId: string,
+): Promise<ResolveBylawsResult> {
+  const vote = await prisma.vote.findUnique({
+    where: { id: voteId },
+    select: { id: true, buildingId: true, linkedBylawsProposalId: true },
+  });
+  if (!vote?.linkedBylawsProposalId) return { applied: false, reason: "NOT_BYLAWS_VOTE" };
+
+  const proposal = await prisma.bylawsChangeProposal.findUnique({
+    where: { id: vote.linkedBylawsProposalId },
+  });
+  if (!proposal || proposal.status !== "PENDING_VOTE") {
+    return { applied: false, reason: "NOT_PENDING" };
+  }
+
+  const { passed } = await calculateVoteResult(voteId);
+
+  if (!passed) {
+    await prisma.bylawsChangeProposal.update({
+      where: { id: proposal.id },
+      data: { status: "REJECTED" },
+    });
+    await createAuditLog({
+      entityType: "BylawsChangeProposal",
+      entityId: proposal.id,
+      action: "UPDATE",
+      userId: closedByUserId,
+      buildingId: vote.buildingId,
+      oldValue: { status: "PENDING_VOTE" },
+      newValue: { status: "REJECTED" },
+    });
+    return { applied: false, reason: "REJECTED" };
+  }
+
+  // Apply only the fields the proposal actually set.
+  const data: {
+    reserveTargetHUF?: bigint;
+    defaultMajority?: MajorityType;
+    costAllocationBasis?: CostAllocationBasis;
+  } = {};
+  const auditApplied: Record<string, unknown> = {};
+  if (proposal.reserveTargetHUF != null) {
+    data.reserveTargetHUF = proposal.reserveTargetHUF;
+    auditApplied.reserveTargetHUF = Number(proposal.reserveTargetHUF);
+  }
+  if (proposal.defaultMajority != null) {
+    data.defaultMajority = proposal.defaultMajority;
+    auditApplied.defaultMajority = proposal.defaultMajority;
+  }
+  if (proposal.costAllocationBasis != null) {
+    data.costAllocationBasis = proposal.costAllocationBasis;
+    auditApplied.costAllocationBasis = proposal.costAllocationBasis;
+  }
+
+  await prisma.$transaction([
+    ...(Object.keys(data).length
+      ? [prisma.building.update({ where: { id: vote.buildingId }, data })]
+      : []),
+    prisma.bylawsChangeProposal.update({
+      where: { id: proposal.id },
+      data: { status: "APPLIED", appliedAt: new Date() },
+    }),
+  ]);
+  await createAuditLog({
+    entityType: "BylawsChangeProposal",
+    entityId: proposal.id,
+    action: "UPDATE",
+    userId: closedByUserId,
+    buildingId: vote.buildingId,
+    oldValue: { status: "PENDING_VOTE" },
+    newValue: { status: "APPLIED", applied: auditApplied },
+  });
+  return { applied: true, proposalId: proposal.id };
+}

--- a/tests/integration/bylaws-proposal.test.ts
+++ b/tests/integration/bylaws-proposal.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prisma } from "@/lib/prisma";
+import { makeBuilding, makeUser } from "../fixtures";
+
+/**
+ * Bylaws change via assembly resolution: proposing creates a linked YES/NO
+ * vote; the change applies only when that vote closes as passed.
+ */
+const { ctxMock } = vi.hoisted(() => ({ ctxMock: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ requireBuildingContext: ctxMock, getCurrentUser: vi.fn(), auth: vi.fn() }));
+vi.mock("@/lib/authz", () => ({ requireCapability: vi.fn(), allows: vi.fn(() => true) }));
+vi.mock("@/lib/audit", () => ({ createAuditLog: vi.fn().mockResolvedValue(undefined) }));
+
+const { proposeBylawsChange } = await import("@/app/actions/bylaws");
+const { resolveBylawsProposal } = await import("@/lib/voting/bylaws-proposal");
+
+beforeEach(() => ctxMock.mockReset());
+
+async function meetingIn(buildingId: string) {
+  const creator = await makeUser({ buildingId, role: "ADMIN" });
+  return prisma.meeting.create({
+    data: { title: "Közgyűlés", date: new Date(), time: "18:00", buildingId, createdById: creator.id },
+  });
+}
+
+/** Build a proposal + backing vote + a single-owner (100% share) YES/NO vote,
+ *  casting `yes` (or not) so calculateVoteResult can tally it. */
+async function proposalWithVote(buildingId: string, opts: { yes: boolean }) {
+  const unit = await prisma.unit.create({
+    data: { number: "1", floor: 1, size: 50, ownershipShare: 1, buildingId },
+  });
+  const proposal = await prisma.bylawsChangeProposal.create({
+    data: { buildingId, proposedById: "proposer", reserveTargetHUF: BigInt(9_000_000) },
+  });
+  const vote = await prisma.vote.create({
+    data: {
+      title: "SZMSZ módosítás",
+      voteType: "YES_NO",
+      status: "OPEN",
+      majorityType: "TWO_THIRDS",
+      quorumRequired: 0.51,
+      deadline: new Date(Date.now() + 86400000),
+      buildingId,
+      createdById: (await makeUser({ buildingId, role: "ADMIN" })).id,
+      linkedBylawsProposalId: proposal.id,
+      options: {
+        create: [
+          { label: "Igen", sortOrder: 0 },
+          { label: "Nem", sortOrder: 1 },
+          { label: "Tartózkodás", sortOrder: 2 },
+        ],
+      },
+    },
+    include: { options: { orderBy: { sortOrder: "asc" } } },
+  });
+  const targetOption = opts.yes ? vote.options[0] : vote.options[1];
+  await prisma.ballot.create({
+    data: { voteId: vote.id, optionId: targetOption.id, unitId: unit.id, weight: 1 },
+  });
+  return { proposal, vote };
+}
+
+describe("bylaws change — propose", () => {
+  it("creates a PENDING_VOTE proposal + a linked YES/NO qualified vote", async () => {
+    const { building } = await makeBuilding();
+    const meeting = await meetingIn(building.id);
+    const proposer = await makeUser({ buildingId: building.id, role: "ADMIN" });
+    ctxMock.mockResolvedValue({ userId: proposer.id, buildingId: building.id, role: "ADMIN" });
+
+    const res = await proposeBylawsChange({ meetingId: meeting.id, reserveTargetHUF: 9_000_000 });
+    expect(res.success).toBe(true);
+
+    const proposal = await prisma.bylawsChangeProposal.findUnique({ where: { id: res.proposalId! } });
+    expect(proposal?.status).toBe("PENDING_VOTE");
+    const vote = await prisma.vote.findUnique({ where: { id: res.voteId! }, include: { options: true } });
+    expect(vote?.linkedBylawsProposalId).toBe(res.proposalId);
+    expect(vote?.majorityType).toBe("TWO_THIRDS");
+    expect(vote?.voteType).toBe("YES_NO");
+    expect(vote?.options).toHaveLength(3);
+  });
+
+  it("rejects an empty changeset", async () => {
+    const { building } = await makeBuilding();
+    const meeting = await meetingIn(building.id);
+    ctxMock.mockResolvedValue({ userId: "u1", buildingId: building.id, role: "ADMIN" });
+    const res = await proposeBylawsChange({ meetingId: meeting.id });
+    expect(res.error).toMatch(/at least one/i);
+  });
+
+  it("rejects a meeting from another building", async () => {
+    const { building } = await makeBuilding();
+    const other = await makeBuilding({ name: "Other" });
+    const meeting = await meetingIn(other.building.id);
+    ctxMock.mockResolvedValue({ userId: "u1", buildingId: building.id, role: "ADMIN" });
+    const res = await proposeBylawsChange({ meetingId: meeting.id, reserveTargetHUF: 1 });
+    expect(res.error).toMatch(/not found/i);
+  });
+});
+
+describe("bylaws change — resolve on vote close", () => {
+  it("applies the change to the building when the vote passes", async () => {
+    const { building } = await makeBuilding();
+    const { proposal, vote } = await proposalWithVote(building.id, { yes: true });
+    const r = await resolveBylawsProposal(vote.id, "closer");
+    expect(r.applied).toBe(true);
+    const b = await prisma.building.findUnique({ where: { id: building.id } });
+    expect(Number(b?.reserveTargetHUF)).toBe(9_000_000);
+    const p = await prisma.bylawsChangeProposal.findUnique({ where: { id: proposal.id } });
+    expect(p?.status).toBe("APPLIED");
+    expect(p?.appliedAt).not.toBeNull();
+  });
+
+  it("rejects (no change) when the vote fails the majority", async () => {
+    const { building } = await makeBuilding();
+    const before = await prisma.building.findUnique({ where: { id: building.id } });
+    const { proposal, vote } = await proposalWithVote(building.id, { yes: false });
+    const r = await resolveBylawsProposal(vote.id, "closer");
+    expect(r.applied).toBe(false);
+    const b = await prisma.building.findUnique({ where: { id: building.id } });
+    expect(Number(b?.reserveTargetHUF)).toBe(Number(before?.reserveTargetHUF)); // unchanged
+    const p = await prisma.bylawsChangeProposal.findUnique({ where: { id: proposal.id } });
+    expect(p?.status).toBe("REJECTED");
+  });
+});


### PR DESCRIPTION
The third follow-up: **modify bylaws tied to an in-app vote**. Engine PR (UI follows). Mirrors the marketplace award-vote pattern — a governance change is proposed, backed by a közgyűlés vote, and applied **only when that vote passes**.

## What
- **Schema**: `BylawsChangeProposal` + `BylawsProposalStatus` (PENDING_VOTE/APPLIED/REJECTED/CANCELLED) + `Vote.linkedBylawsProposalId` (unique) + migration.
- **Capability**: `bylaws.modify` — representative authority or ADMIN by default; delegatable to a board member via the `modify_bylaws` grant (through `GRANT_UNLOCKS`).
- **`proposeBylawsChange`** action: creates the proposal + a **YES/NO qualified vote** (default **TWO_THIRDS**) at a meeting, linked to the proposal. Validates the changeset (reserve target / majority / cost basis) and the meeting.
- **`resolveBylawsProposal`**: on the linked vote closing, uses the existing `calculateVoteResult` to check pass/fail (per the vote's `majorityType`); on pass, **applies the changeset to the Building**; else marks **REJECTED**. Wired into the vote-close handler next to `resolveAwardVote`. Fully audited.

## Tests
5 integration tests: propose (happy + empty-changeset + cross-building guards), resolve **applies on pass** (building updated, APPLIED), resolve **rejects on fail** (building unchanged, REJECTED). **310 tests pass**; `tsc` + `eslint` clean.

## Next
UI to propose a change + track its status (likely from the governance/settings surface). This completes the three previously-cosmetic toggles: delete_resident (#109/#110) and now modify_bylaws are real; edit_resident_contact was dropped (#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)