### PR TITLE
monitoring: deliver Prometheus alerts by email via Alertmanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ yarn-error.log*
 .env
 .env*.local
 
+# rendered Alertmanager config — contains SMTP creds; Ansible renders it on the
+# server from ansible/templates/alertmanager.yml.j2
+monitoring/alertmanager/alertmanager.yml
+
 # vercel
 .vercel
 

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -24,6 +24,18 @@
         dest: "{{ mon_dir }}/.env"
         mode: "0600"
 
+    - name: Ensure the alertmanager config directory exists
+      ansible.builtin.file:
+        path: "{{ mon_dir }}/alertmanager"
+        state: directory
+        mode: "0755"
+
+    - name: Template the Alertmanager config (SMTP creds — reuses the app relay)
+      ansible.builtin.template:
+        src: templates/alertmanager.yml.j2
+        dest: "{{ mon_dir }}/alertmanager/alertmanager.yml"
+        mode: "0600"
+
     - name: Pull and start the monitoring stack
       ansible.builtin.command:
         cmd: docker compose up -d --pull always
@@ -35,6 +47,9 @@
 
     - name: Wait for Grafana
       ansible.builtin.wait_for: { host: 127.0.0.1, port: 3001, timeout: 60 }
+
+    - name: Wait for Alertmanager
+      ansible.builtin.wait_for: { host: 127.0.0.1, port: 9093, timeout: 60 }
 
     - name: Query Prometheus for scrape-target health
       ansible.builtin.uri:

--- a/ansible/secrets.example.yml
+++ b/ansible/secrets.example.yml
@@ -30,3 +30,10 @@ smtp_port: "465"
 smtp_user: "resend"
 smtp_pass: "REPLACE_WITH_PROVIDER_API_KEY_OR_SMTP_PASSWORD"
 smtp_from: "Condo Manager <noreply@yourdomain.example>"
+
+# --- monitoring alerts (Alertmanager) ---
+# Where Prometheus alerts (disk full, host down, app down, ...) are emailed.
+# Reuses the smtp_* relay above. Alertmanager uses STARTTLS, so it needs a
+# STARTTLS port (587) rather than the app's implicit-TLS 465.
+alert_email_to: "you@yourdomain.example"
+alert_smtp_port: "587"

--- a/ansible/templates/alertmanager.yml.j2
+++ b/ansible/templates/alertmanager.yml.j2
@@ -1,0 +1,30 @@
+# Rendered by Ansible onto the server as monitoring/alertmanager/alertmanager.yml
+# (0600). Reuses the SAME SMTP relay the app uses for its own mail — the smtp_*
+# values live in ansible/secrets.yml, so credentials are never committed.
+#
+# NOTE ON PORT: the app sends on 465 (implicit TLS), but Alertmanager speaks
+# STARTTLS, so it uses 587 by default (alert_smtp_port). require_tls stays true.
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: "{{ smtp_host }}:{{ alert_smtp_port | default('587') }}"
+  smtp_from: "{{ smtp_from }}"
+  smtp_auth_username: "{{ smtp_user }}"
+  smtp_auth_password: "{{ smtp_pass }}"
+  smtp_require_tls: true
+
+route:
+  receiver: email
+  # Collapse alerts that share an alertname into one mail, then hold briefly so a
+  # burst arrives together rather than as a storm.
+  group_by: ["alertname"]
+  group_wait: 30s
+  group_interval: 5m
+  # Re-send a still-firing alert at most this often (so a lingering disk-full
+  # nags daily instead of every few minutes).
+  repeat_interval: 24h
+
+receivers:
+  - name: email
+    email_configs:
+      - to: "{{ alert_email_to }}"
+        send_resolved: true # also mail when the condition clears

--- a/monitoring/alertmanager/README.md
+++ b/monitoring/alertmanager/README.md
@@ -1,0 +1,13 @@
+# Alertmanager config
+
+`alertmanager.yml` in this directory is **not committed** — it holds SMTP
+credentials. Ansible renders it on the server from
+`ansible/templates/alertmanager.yml.j2` using the `smtp_*` / `alert_*` values in
+`ansible/secrets.yml`, then `docker compose` mounts it into the container.
+
+This directory (with this README) is committed only so the mount path exists in
+the repo. To (re)deploy:
+
+```sh
+cd ansible && ansible-playbook monitoring.yml -e @secrets.yml
+```

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -88,11 +88,29 @@ services:
       - "127.0.0.1:12345:12345" # Alloy's own UI (localhost only)
     depends_on: [loki]
 
+  # Alertmanager: receives firing alerts from Prometheus and delivers them (here,
+  # by email). Prometheus only *evaluates* rules — without this, alerts fire into
+  # the void (which is exactly why the 2026-06-30 disk-full went unnoticed). The
+  # config is rendered by Ansible from ansible/secrets.yml (SMTP creds), so it's
+  # NOT committed — see ansible/templates/alertmanager.yml.j2.
+  alertmanager:
+    image: prom/alertmanager:latest
+    restart: unless-stopped
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanagerdata:/alertmanager
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    ports:
+      - "127.0.0.1:9093:9093" # Alertmanager UI (localhost only)
+
 volumes:
   promdata:
   grafanadata:
   lokidata:
   alloydata:
+  alertmanagerdata:
 
 networks:
   default: {} # this monitoring project's own network

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -7,6 +7,13 @@ global:
 rule_files:
   - /etc/prometheus/alerts.yml
 
+# Where to send firing alerts. Alertmanager runs in this same compose project,
+# reachable by service name on the monitoring network.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   - job_name: prometheus # Prometheus scraping itself
     static_configs:


### PR DESCRIPTION
## Why
The disk-usage alert (`HostDiskAlmostFull`, >85%/10m) — and `TargetDown`, `AppDown`, `HostHighCPU`, `HostLowMemory` — **already existed** in `monitoring/prometheus/alerts.yml`. But Prometheus had **no `alerting:` block**, so nothing was ever delivered; alerts only appeared in the Prometheus UI. That's why the **2026-06-30 disk-full** (root at 100% → unclean reboot → Postgres crash-loop) went unnoticed until it was investigated after the fact.

## What
Stand up **Alertmanager** and route alerts to it, delivering firing **and** resolved notifications by **email** — reusing the **same SMTP relay the app already uses** (`smtp_*` in `ansible/secrets.yml`), so no new provider or secret is introduced.

- `monitoring/docker-compose.yml` — `alertmanager` service on `127.0.0.1:9093` + persistent volume
- `monitoring/prometheus/prometheus.yml` — `alerting:` → `alertmanager:9093`
- `ansible/templates/alertmanager.yml.j2` — config **rendered on the server** with the SMTP creds (never committed). Uses **STARTTLS on 587** because Alertmanager doesn't speak the app's implicit-TLS **465**
- `ansible/monitoring.yml` — ensure the alertmanager dir, render its config, wait on `:9093`
- `ansible/secrets.example.yml` — new `alert_email_to` + `alert_smtp_port`
- `.gitignore` — ignore the rendered `monitoring/alertmanager/alertmanager.yml`

## Deploy
Set `alert_email_to` (and confirm `smtp_*`) in `ansible/secrets.yml`, then:
```sh
cd ansible && ansible-playbook monitoring.yml -e @secrets.yml
```
Note: `monitoring/**` and `ansible/**` are in the CI `paths-ignore`, so this **won't auto-deploy** — it's an intentional manual Ansible step.

## Validation done
- `prometheus.yml` parses; `alerting` block points at `alertmanager:9093`
- `docker compose config` shows the alertmanager service, `:9093` bind, config mount, and volume
- `alertmanager.yml.j2` renders to valid YAML with mock vars (`smarthost: smtp.resend.com:587`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)