### PR TITLE
feat(governance): bylaws/governance settings page + propose UI

### DIFF
--- a/src/app/[locale]/dashboard/governance/page.tsx
+++ b/src/app/[locale]/dashboard/governance/page.tsx
@@ -1,0 +1,26 @@
+import { setRequestLocale } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { allows } from "@/lib/authz";
+import { getDashboardContext } from "@/lib/dal";
+import { getGovernanceOverview } from "@/lib/governance-dal";
+import { GovernancePanel } from "@/components/governance/governance-panel";
+
+type Props = { params: Promise<{ locale: string }> };
+
+/**
+ * Governance / bylaws page — board-only. Shows the current settings and, for
+ * users who may modify bylaws, a "propose change" form. Changes are applied
+ * only via a passing assembly vote (see proposeBylawsChange / resolveBylawsProposal).
+ */
+export default async function GovernancePage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const ctx = await getDashboardContext();
+  if (!allows(ctx, "view.boardContext")) {
+    redirect(`/${locale}/dashboard`);
+  }
+
+  const data = await getGovernanceOverview();
+  return <GovernancePanel locale={locale} data={data} />;
+}

--- a/src/components/governance/governance-panel.tsx
+++ b/src/components/governance/governance-panel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { proposeBylawsChange } from "@/app/actions/bylaws";
+import type { GovernanceOverview } from "@/lib/governance-dal";
+
+const MAJORITY = ["SIMPLE_MAJORITY", "TWO_THIRDS", "FOUR_FIFTHS", "UNANIMOUS"] as const;
+const COST_BASIS = ["OWNERSHIP_SHARE", "EQUAL", "AREA"] as const;
+
+export function GovernancePanel({
+  locale,
+  data,
+}: {
+  locale: string;
+  data: GovernanceOverview;
+}) {
+  const t = useTranslations("governance");
+  const tg = useTranslations("buildingOnboarding");
+  const router = useRouter();
+  const nf = new Intl.NumberFormat(locale === "en" ? "en-US" : "hu-HU");
+
+  const [open, setOpen] = useState(false);
+  const [reserve, setReserve] = useState("");
+  const [majority, setMajority] = useState(""); // "" = no change
+  const [basis, setBasis] = useState("");
+  const [voteMajority, setVoteMajority] = useState("TWO_THIRDS");
+  const [meetingId, setMeetingId] = useState(data.upcomingMeetings[0]?.id ?? "");
+  const [busy, setBusy] = useState(false);
+
+  const hasChange = reserve.trim() !== "" || majority !== "" || basis !== "";
+
+  async function submit() {
+    setBusy(true);
+    try {
+      const res = await proposeBylawsChange({
+        meetingId,
+        reserveTargetHUF: reserve.trim() !== "" ? Number(reserve) : null,
+        defaultMajority: majority || null,
+        costAllocationBasis: basis || null,
+        voteMajorityType: voteMajority,
+      });
+      if (res.error) {
+        toast.error(res.error);
+        return;
+      }
+      toast.success(t("proposeSuccess"));
+      setOpen(false);
+      setReserve(""); setMajority(""); setBasis("");
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: "760px", margin: "0 auto", padding: "32px 28px 80px" }}>
+      <h1 style={{ fontFamily: "var(--font-space-grotesk), sans-serif", fontSize: "32px", fontWeight: 500, letterSpacing: "-0.03em" }}>
+        {t("title")}
+      </h1>
+      <p style={{ color: "var(--color-ink-soft)", margin: "6px 0 24px", maxWidth: "60ch" }}>{t("subtitle")}</p>
+
+      {/* Current settings */}
+      <div style={card}>
+        <SettingRow label={t("reserveTarget")} value={`${nf.format(data.reserveTargetHUF)} Ft`} />
+        <SettingRow label={t("majority")} value={tg(`majority.${data.defaultMajority}`)} />
+        <SettingRow label={t("costBasis")} value={tg(`costBasis.${data.costAllocationBasis}`)} last />
+      </div>
+
+      {/* Propose */}
+      {data.canPropose && (
+        <div style={{ marginTop: "18px" }}>
+          {!open ? (
+            <button type="button" onClick={() => setOpen(true)} style={primaryBtn}>
+              {t("proposeCta")}
+            </button>
+          ) : (
+            <div style={card}>
+              <div style={{ fontSize: "15px", fontWeight: 600, marginBottom: "4px" }}>{t("proposeTitle")}</div>
+              <p className="font-mono" style={{ fontSize: "11px", color: "var(--color-muted)", margin: "0 0 14px", letterSpacing: "0.02em" }}>
+                {t("assemblyNote")}
+              </p>
+
+              <Field label={t("reserveTarget")}>
+                <input type="number" min={0} step={100000} value={reserve} onChange={(e) => setReserve(e.target.value)} placeholder={t("noChange")} style={input} />
+              </Field>
+              <Field label={t("majority")}>
+                <select value={majority} onChange={(e) => setMajority(e.target.value)} style={input}>
+                  <option value="">{t("noChange")}</option>
+                  {MAJORITY.map((m) => <option key={m} value={m}>{tg(`majority.${m}`)}</option>)}
+                </select>
+              </Field>
+              <Field label={t("costBasis")}>
+                <select value={basis} onChange={(e) => setBasis(e.target.value)} style={input}>
+                  <option value="">{t("noChange")}</option>
+                  {COST_BASIS.map((c) => <option key={c} value={c}>{tg(`costBasis.${c}`)}</option>)}
+                </select>
+              </Field>
+
+              <div style={{ height: "1px", background: "color-mix(in srgb, var(--color-ink) 8%, transparent)", margin: "8px 0 14px" }} />
+
+              <Field label={t("voteMajority")} hint={t("voteMajorityHint")}>
+                <select value={voteMajority} onChange={(e) => setVoteMajority(e.target.value)} style={input}>
+                  {MAJORITY.map((m) => <option key={m} value={m}>{tg(`majority.${m}`)}</option>)}
+                </select>
+              </Field>
+              <Field label={t("meeting")}>
+                {data.upcomingMeetings.length === 0 ? (
+                  <p style={{ fontSize: "13px", color: "var(--color-ochre)" }}>{t("noMeeting")}</p>
+                ) : (
+                  <select value={meetingId} onChange={(e) => setMeetingId(e.target.value)} style={input}>
+                    {data.upcomingMeetings.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.title} · {new Date(m.date).toLocaleDateString(locale === "en" ? "en-US" : "hu-HU")}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </Field>
+
+              <div className="flex gap-2" style={{ marginTop: "12px" }}>
+                <button type="button" onClick={submit} disabled={busy || !hasChange || !meetingId} style={{ ...primaryBtn, opacity: !hasChange || !meetingId ? 0.5 : 1 }}>
+                  {busy ? "…" : t("submitProposal")}
+                </button>
+                <button type="button" onClick={() => setOpen(false)} disabled={busy} style={ghostBtn}>{t("cancel")}</button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Proposals history */}
+      <div style={{ marginTop: "26px" }}>
+        <h2 className="font-mono" style={{ fontSize: "11px", color: "var(--color-muted)", letterSpacing: "0.08em", textTransform: "uppercase", marginBottom: "10px" }}>
+          {t("proposalsTitle")}
+        </h2>
+        {data.proposals.length === 0 ? (
+          <p style={{ fontSize: "13px", color: "var(--color-muted)" }}>{t("noProposals")}</p>
+        ) : (
+          <div className="grid gap-2">
+            {data.proposals.map((p) => (
+              <div key={p.id} style={{ ...card, padding: "12px 14px" }} className="flex items-center justify-between gap-3">
+                <div style={{ fontSize: "13px" }}>
+                  <div style={{ fontWeight: 600 }}>
+                    {[
+                      p.reserveTargetHUF != null ? `${t("reserveTarget")}: ${nf.format(p.reserveTargetHUF)} Ft` : null,
+                      p.defaultMajority ? tg(`majority.${p.defaultMajority}`) : null,
+                      p.costAllocationBasis ? tg(`costBasis.${p.costAllocationBasis}`) : null,
+                    ].filter(Boolean).join(" · ")}
+                  </div>
+                  <div className="font-mono" style={{ fontSize: "10.5px", color: "var(--color-muted)", marginTop: "2px" }}>
+                    {new Date(p.createdAt).toLocaleDateString(locale === "en" ? "en-US" : "hu-HU")}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <StatusBadge status={p.status} label={t(`status.${p.status}`)} />
+                  {p.status === "PENDING_VOTE" && p.voteId && (
+                    <Link href={`/${locale}/voting`} style={{ fontSize: "12px", fontWeight: 600, color: "var(--color-blue)" }}>
+                      {t("openVote")} →
+                    </Link>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SettingRow({ label, value, last }: { label: string; value: string; last?: boolean }) {
+  return (
+    <div className="flex items-center justify-between" style={{ padding: "10px 0", borderBottom: last ? "none" : "1px solid color-mix(in srgb, var(--color-ink) 7%, transparent)" }}>
+      <span style={{ fontSize: "13px", color: "var(--color-ink-soft)" }}>{label}</span>
+      <span style={{ fontSize: "14px", fontWeight: 600 }}>{value}</span>
+    </div>
+  );
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: "12px" }}>
+      <label className="block" style={{ fontSize: "13px", fontWeight: 600, marginBottom: "5px" }}>{label}</label>
+      {children}
+      {hint && <p className="font-mono" style={{ fontSize: "10.5px", color: "var(--color-muted)", marginTop: "4px" }}>{hint}</p>}
+    </div>
+  );
+}
+
+function StatusBadge({ status, label }: { status: string; label: string }) {
+  const color =
+    status === "APPLIED" ? "var(--color-moss)" : status === "REJECTED" || status === "CANCELLED" ? "var(--color-danger)" : "var(--color-ochre)";
+  return (
+    <span className="font-mono" style={{ fontSize: "10px", fontWeight: 700, letterSpacing: "0.05em", textTransform: "uppercase", color, padding: "3px 8px", borderRadius: "6px", background: `color-mix(in srgb, ${color} 12%, transparent)` }}>
+      {label}
+    </span>
+  );
+}
+
+const card: React.CSSProperties = { background: "var(--color-card)", border: "1px solid color-mix(in srgb, var(--color-ink) 10%, transparent)", borderRadius: "14px", padding: "18px 20px" };
+const input: React.CSSProperties = { width: "100%", padding: "9px 12px", borderRadius: "9px", fontSize: "14px", border: "1px solid color-mix(in srgb, var(--color-ink) 15%, transparent)", background: "var(--color-bg)", color: "var(--color-ink)" };
+const primaryBtn: React.CSSProperties = { padding: "10px 16px", borderRadius: "9px", fontSize: "13px", fontWeight: 600, background: "var(--color-ink)", color: "var(--color-bg)", border: "none", cursor: "pointer" };
+const ghostBtn: React.CSSProperties = { padding: "10px 16px", borderRadius: "9px", fontSize: "13px", fontWeight: 600, background: "var(--color-card)", color: "var(--color-ink)", border: "1px solid color-mix(in srgb, var(--color-ink) 12%, transparent)", cursor: "pointer" };

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -216,6 +216,7 @@ const sections: NavSection[] = [
       // their own unit, not on the building's full register.)
       { key: "units", href: "/units", icon: Icons.units, capabilities: ["units.manage"] },
       { key: "residents", href: "/residents", icon: Icons.residents },
+      { key: "governance", href: "/dashboard/governance", icon: Icons.documents, capabilities: ["view.boardContext"] },
     ],
   },
   {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -49,6 +49,7 @@
     "admin": "Administration",
     "users": "Users",
     "residents": "Residents",
+    "governance": "Governance",
     "buildingFinance": "Building Finance",
     "maintenanceContractors": "Contractors",
     "maintenanceScheduled": "Scheduled",
@@ -3051,6 +3052,33 @@
     "doneTitle": "Setup complete",
     "doneBody": "Your building's basics are configured. You can revise any step later.",
     "doneCta": "Back to dashboard"
+  },
+  "governance": {
+    "title": "Governance",
+    "subtitle": "The building's financial and decision-making settings. Changes require an assembly resolution (a vote).",
+    "reserveTarget": "Reserve-fund target",
+    "majority": "Default voting majority",
+    "costBasis": "Cost-allocation basis",
+    "proposeCta": "Propose a change",
+    "proposeTitle": "Propose a bylaws change",
+    "assemblyNote": "The change only takes effect if the backing assembly vote passes.",
+    "noChange": "No change",
+    "voteMajority": "Required voting majority",
+    "voteMajorityHint": "Bylaws changes typically need a qualified majority.",
+    "meeting": "Meeting",
+    "noMeeting": "No upcoming meeting — create one first.",
+    "submitProposal": "Submit proposal",
+    "cancel": "Cancel",
+    "proposeSuccess": "Proposal created and awaiting the vote.",
+    "proposalsTitle": "Change proposals",
+    "noProposals": "No proposals yet.",
+    "openVote": "Open vote",
+    "status": {
+      "PENDING_VOTE": "Awaiting vote",
+      "APPLIED": "Applied",
+      "REJECTED": "Rejected",
+      "CANCELLED": "Cancelled"
+    }
   },
   "dashboard": {
     "newTask": "New task",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -49,6 +49,7 @@
     "admin": "Adminisztráció",
     "users": "Felhasználók",
     "residents": "Lakók",
+    "governance": "Önkormányzás",
     "buildingFinance": "Épület pénzügyek",
     "maintenanceContractors": "Kivitelezők",
     "maintenanceScheduled": "Ütemezett",
@@ -3051,6 +3052,33 @@
     "doneTitle": "Beüzemelés kész",
     "doneBody": "A társasház alapbeállításai elkészültek. Bármelyik lépést később is módosíthatod.",
     "doneCta": "Vissza az áttekintéshez"
+  },
+  "governance": {
+    "title": "Önkormányzás",
+    "subtitle": "A társasház gazdálkodási és döntéshozatali beállításai. A módosításokhoz közgyűlési határozat (szavazás) szükséges.",
+    "reserveTarget": "Tartalékalap cél",
+    "majority": "Alapértelmezett szavazási többség",
+    "costBasis": "Költségmegosztás alapja",
+    "proposeCta": "Módosítás kezdeményezése",
+    "proposeTitle": "Bylaws módosítás javaslata",
+    "assemblyNote": "A módosítás csak akkor lép életbe, ha a hozzá tartozó közgyűlési szavazás elfogadja.",
+    "noChange": "Nincs változás",
+    "voteMajority": "Szükséges szavazási többség",
+    "voteMajorityHint": "SZMSZ-módosításhoz jellemzően minősített többség kell.",
+    "meeting": "Közgyűlés",
+    "noMeeting": "Nincs közelgő közgyűlés — előbb hozz létre egyet.",
+    "submitProposal": "Javaslat beküldése",
+    "cancel": "Mégse",
+    "proposeSuccess": "A javaslat létrejött, és szavazásra vár.",
+    "proposalsTitle": "Módosítási javaslatok",
+    "noProposals": "Még nincs javaslat.",
+    "openVote": "Szavazás megnyitása",
+    "status": {
+      "PENDING_VOTE": "Szavazásra vár",
+      "APPLIED": "Alkalmazva",
+      "REJECTED": "Elutasítva",
+      "CANCELLED": "Visszavonva"
+    }
   },
   "dashboard": {
     "newTask": "Új teendő",

--- a/src/lib/governance-dal.ts
+++ b/src/lib/governance-dal.ts
@@ -1,0 +1,86 @@
+import "server-only";
+import { cache } from "react";
+import { prisma } from "@/lib/prisma";
+import { requireBuildingContext } from "@/lib/auth";
+import { allows } from "@/lib/authz";
+
+export interface GovernanceProposal {
+  id: string;
+  status: string;
+  reserveTargetHUF: number | null;
+  defaultMajority: string | null;
+  costAllocationBasis: string | null;
+  voteId: string | null;
+  voteStatus: string | null;
+  createdAt: string;
+}
+
+export interface GovernanceOverview {
+  reserveTargetHUF: number;
+  defaultMajority: string;
+  costAllocationBasis: string;
+  /** Whether the viewer may propose a change (bylaws.modify). */
+  canPropose: boolean;
+  /** Upcoming meetings a proposal's vote can be attached to. */
+  upcomingMeetings: { id: string; title: string; date: string }[];
+  proposals: GovernanceProposal[];
+}
+
+/**
+ * Governance / bylaws overview: the building's current settings, whether the
+ * viewer can propose a change, upcoming meetings to attach the backing vote to,
+ * and the history of change proposals with their status.
+ */
+export const getGovernanceOverview = cache(
+  async (): Promise<GovernanceOverview> => {
+    const ctx = await requireBuildingContext();
+    const { buildingId } = ctx;
+    const canPropose = allows(ctx, "bylaws.modify");
+    const now = new Date();
+
+    const [building, meetings, proposals] = await Promise.all([
+      prisma.building.findUnique({
+        where: { id: buildingId },
+        select: {
+          reserveTargetHUF: true,
+          defaultMajority: true,
+          costAllocationBasis: true,
+        },
+      }),
+      prisma.meeting.findMany({
+        where: { buildingId, date: { gte: now } },
+        orderBy: { date: "asc" },
+        select: { id: true, title: true, date: true },
+        take: 20,
+      }),
+      prisma.bylawsChangeProposal.findMany({
+        where: { buildingId },
+        orderBy: { createdAt: "desc" },
+        take: 20,
+        include: { vote: { select: { id: true, status: true } } },
+      }),
+    ]);
+
+    return {
+      reserveTargetHUF: Number(building?.reserveTargetHUF ?? 0),
+      defaultMajority: building?.defaultMajority ?? "SIMPLE_MAJORITY",
+      costAllocationBasis: building?.costAllocationBasis ?? "OWNERSHIP_SHARE",
+      canPropose,
+      upcomingMeetings: meetings.map((m) => ({
+        id: m.id,
+        title: m.title,
+        date: m.date.toISOString(),
+      })),
+      proposals: proposals.map((p) => ({
+        id: p.id,
+        status: p.status,
+        reserveTargetHUF: p.reserveTargetHUF != null ? Number(p.reserveTargetHUF) : null,
+        defaultMajority: p.defaultMajority,
+        costAllocationBasis: p.costAllocationBasis,
+        voteId: p.vote?.id ?? null,
+        voteStatus: p.vote?.status ?? null,
+        createdAt: p.createdAt.toISOString(),
+      })),
+    };
+  },
+);


### PR DESCRIPTION
The UI for the bylaws engine (#112) — a dedicated **Governance** page (option 2), completing the modify_bylaws workflow.

## What
New board-only page at `/dashboard/governance` (sidebar **"Önkormányzás"**, gated on `view.boardContext`):
- **Current settings** — reserve-fund target, default majority, cost-allocation basis (translated labels).
- **Propose a change** (only for `bylaws.modify` holders) — pick which of reserve/majority/cost-basis to change, the required voting majority (default two-thirds), and the meeting to attach the vote to → `proposeBylawsChange` creates the proposal + backing közgyűlés vote. The change applies automatically only when that vote passes.
- **Proposals list** — status badges (awaiting vote / applied / rejected / cancelled) with a link to the backing vote.
- `getGovernanceOverview` DAL.

## Validation (live, tailnet)
Rendered as a board member: page shows current settings (Egyszerű többség / Tulajdoni hányad szerint), the propose CTA (visible because the chair holds `bylaws.modify`), and the empty proposals list; sidebar link works; console clean. `tsc` + `eslint` clean. The propose→vote→apply logic is covered by the engine's 5 integration tests (#112).

## Wrap-up
This closes the "build out the three toggles" work: **edit_resident_contact** dropped (#108), **delete_resident** = dual-control removal (#109/#110), **modify_bylaws** = assembly-resolution engine (#112) + this UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)