### PR TITLE
fix(onboarding): don't duplicate the SZMSZ document on re-upload

### DIFF
--- a/src/app/api/onboarding/extract-szmsz/route.ts
+++ b/src/app/api/onboarding/extract-szmsz/route.ts
@@ -62,10 +62,21 @@ export async function POST(request: NextRequest) {
         orderBy: { sortOrder: "asc" },
         select: { id: true },
       });
+      const title = fileName.replace(/\.pdf$/i, "");
       if (szmszCategory) {
+        // Dedupe: don't pile up documents when the same SZMSZ is re-uploaded
+        // (e.g. retries). If one with this title already exists in the
+        // category, treat it as stored and skip creating another.
+        const existingDoc = await prisma.document.findFirst({
+          where: { categoryId: szmszCategory.id, title, isArchived: false },
+          select: { id: true },
+        });
+        if (existingDoc) {
+          stored = true;
+        } else {
         await prisma.document.create({
           data: {
-            title: fileName.replace(/\.pdf$/i, ""),
+            title,
             categoryId: szmszCategory.id,
             visibility: "BOARD_ONLY",
             uploadedById: ctx.userId,
@@ -82,6 +93,7 @@ export async function POST(request: NextRequest) {
           },
         });
         stored = true;
+        }
       }
     } catch (storeErr) {
       console.error("SZMSZ document store failed (non-fatal):", storeErr);


### PR DESCRIPTION
Re-uploading an SZMSZ (or retrying after an error) created a **new** Bylaws document each time — they piled up (a user hit 4 copies; the earlier stale-Prisma-client failures also each stored one before throwing).

**Fix:** before storing, check the SZMSZ category for a non-archived document with the same title; if present, treat it as already stored and skip creating another. Different filenames still create distinct docs.

Cleaned up the existing duplicates in the affected building (kept the newest). `tsc` + `eslint` clean.

_(Follow-up idea: on genuine re-upload of an updated SZMSZ, add a new document **version** rather than skip — deferred.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)